### PR TITLE
adding docker build for oras-py

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,50 @@
+name: Build and Deploy Container
+
+on:
+  schedule:
+    - cron: 0 3 * * *
+
+  # Publish packages on release
+  release:
+    types: [published] 
+
+  pull_request: []
+
+  # On push to main we build and deploy images
+  push: 
+    branches:
+      - main
+ 
+jobs:
+  build:
+    permissions:
+      packages: write
+
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Container
+        run: docker build -t ghcr.io/oras-project/oras-py:latest .
+
+      - name: GHCR Login
+        if: (github.event_name != 'pull_request')
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and Push Release Image
+        if: (github.event_name == 'release')
+        run: |
+            tag=${GITHUB_REF#refs/tags/}
+            echo "Tagging and releasing ghcr.io/oras-project/oras-py:${tag}"
+            docker tag ghcr.io/oras-project/oras-py:latest ghcr.io/oras-project/oras-py:${tag}
+            docker push ghcr.io/oras-project/oras-py:${tag}
+
+      - name: Deploy
+        if: (github.event_name != 'pull_request')
+        run: docker push ghcr.io/oras-project/oras-py:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+# docker build -t oras-py .
+
+LABEL MAINTAINER @vsoch
+ENV PATH /opt/conda/bin:${PATH}
+ENV LANG C.UTF-8
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+RUN pip install ipython
+WORKDIR /code
+COPY . /code
+RUN pip install -e .[all]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ $ cat artifact.txt
 hello dinosaur
 ```
 
+### Docker Container
+
+We provide a [Dockerfile](Dockerfile) to build a container with the client.
+
+```bash
+$ docker build -t oras-py .
+```
+```bash
+$ docker run -it oras-py                                                                                                                   
+# which oras-py
+/opt/conda/bin/oras-py
+```
+
 ## TODO
 
  - should there be a tags function?

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Now try a pull! We will first need to delete the file
 ```bash
 $ rm -f artifact.txt # first delete the file
 $ oras-py pull localhost:5000/dinosaur/artifact:v1
+```
 ```bash
 $ cat artifact.txt
 hello dinosaur


### PR DESCRIPTION
It's nice to have a quick container to pull that has the client installed, either for development or usage.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>