### PR TITLE
Review fixes and example

### DIFF
--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -135,6 +135,14 @@ $ cat artifact.txt
 hello dinosaur
 ```
 
+### Custom Registry
+
+The benefit of Oras Python is that you can create a subclass that easily implements
+a registry, and then allows you to do custom interactions. We provide a few examples:
+
+ - [Conda Mirror](https://github.com/oras-project/oras-py/blob/main/examples/conda-mirror.py): an example to parse custom layers to retrieve metadata index.jsons (and archive) along with a binary to download.
+
+
 ### Docker Container
 
 We provide a [Dockerfile](https://github.com/oras-project/oras-py/blob/main/Dockerfile) to build a container with the client.

--- a/examples/conda-mirror.py
+++ b/examples/conda-mirror.py
@@ -1,0 +1,94 @@
+# This is an example of a custom client described in:
+# https://github.com/oras-project/oras-py/issues/11 that wants to use oras
+# to upload multiple different objects in different layers of a manifest,
+# and then have a custom filter for those layers.
+
+import io
+import json
+import os
+import sys
+import tarfile
+
+import oras.client
+import oras.provider
+
+
+class CondaMirror(oras.provider.Registry):
+    """
+    A CondaMirror is a custom remote to push three layers per conda package:
+     1. .tar.bz2 package file
+     2. index.json file containing metadata and package dependencies
+     3. .tar.gz of the info directory
+
+    For the third, we want to be able to get interesting metadata about the
+    package without actually needing to download it.
+    """
+
+    # We can use media types to organize layers
+    media_types = {
+        "application/vnd.conda.info.v1.tar+gzip": "info_archive",
+        "application/vnd.conda.info.index.v1+json": "info_index",
+        "application/vnd.conda.package.v1": "package_tarbz2",
+        "application/vnd.conda.package.v2": "package_conda",
+    }
+
+    def inspect(self, name):
+
+        # Parse the name into a container
+        container = self.get_container(name)
+
+        # Get the manifest with the three layers
+        manifest = self.get_manifest(container)
+
+        # Organize layers based on media_types
+        layers = self._organize_layers(manifest)
+
+        # Get the index (the function will check the success of the response)
+        if "info_index" in layers:
+            index = self.get_blob(container, layers["info_index"]["digest"]).json()
+            print(json.dumps(index, indent=4))
+
+        # The compressed index
+        if "info_archive" in layers:
+            archive = self.get_blob(container, layers["info_archive"]["digest"])
+            archive = tarfile.open(fileobj=io.BytesIO(archive.content), mode="r:gz")
+            print(archive.members)
+
+        if "package_tarbz2" in layers:
+            print(
+                "Found layer %s that could be extracted to %s."
+                % (
+                    layers["package_tarbz2"]["digest"],
+                    layers["package_tarbz2"]["annotations"][
+                        "org.opencontainers.image.title"
+                    ],
+                )
+            )
+
+    def _organize_layers(self, manifest: dict) -> dict:
+        """
+        Given a manifest, organize based on the media type.
+        """
+        layers = {}
+        for layer in manifest.get("layers", []):
+            if layer["mediaType"] in self.media_types:
+                layers[self.media_types[layer["mediaType"]]] = layer
+        return layers
+
+
+# We will need GitHub personal access token or token
+token = os.environ.get("GITHUB_TOKEN")
+user = os.environ.get("GITHUB_USER")
+
+if not token or not user:
+    sys.exit("GITHUB_TOKEN and GITHUB_USER are required in the environment.")
+
+
+def main():
+    mirror = CondaMirror()
+    mirror.set_basic_auth(user, token)
+    mirror.inspect("ghcr.io/wolfv/conda-forge/linux-64/xtensor:0.9.0-0")
+
+
+if __name__ == "__main__":
+    main()

--- a/oras/auth.py
+++ b/oras/auth.py
@@ -11,7 +11,7 @@ import oras.utils
 from oras.logger import logger
 
 
-def load_configs(configs: List[str] = None):
+def load_configs(configs: Optional[List[str]] = None):
     """
     Load one or more configs with credentials from the filesystem.
 

--- a/oras/client.py
+++ b/oras/client.py
@@ -25,8 +25,8 @@ class OrasClient:
 
     def __init__(
         self,
-        hostname: str = None,
-        registry: oras.provider.Registry = None,
+        hostname: Optional[str] = None,
+        registry: Optional[oras.provider.Registry] = None,
         insecure: bool = False,
     ):
         """
@@ -83,6 +83,17 @@ class OrasClient:
         # Otherwise return a string that can be printed
         return "\n".join(["%s: %s" % (k, v) for k, v in versions.items()])
 
+    def get_tags(self, name: str, N: int = 10_000) -> List[str]:
+        """
+        Retrieve tags for a package.
+
+        Arguments
+        ---------
+        name  : container URI to parse
+        N     : number of tags
+        """
+        return self.remote.get_tags(name, N=N).json()
+
     def push(self, *args, **kwargs):
         """
         Push a container to the remote.
@@ -101,7 +112,7 @@ class OrasClient:
         password: str,
         password_stdin: bool = False,
         insecure: bool = False,
-        hostname: str = None,
+        hostname: Optional[str] = None,
         config_path: Optional[List[str]] = None,
     ):
         """

--- a/oras/container.py
+++ b/oras/container.py
@@ -47,6 +47,9 @@ class Container:
     def upload_blob_url(self) -> str:
         return f"{self.registry}/v2/{self.namespace}/{self.repository}/blobs/uploads/"
 
+    def tags_url(self, N=10_000) -> str:
+        return f"{self.registry}/v2/{self.namespace}/{self.repository}/tags/list?n={N}"
+
     def put_manifest_url(self) -> str:
         return f"{self.registry}/v2/{self.namespace}/{self.repository}/manifests/{self.tag}"
 

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -1,0 +1,26 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright The ORAS Authors."
+__license__ = "Apache-2.0"
+
+from functools import partial, update_wrapper
+
+
+class ensure_container:
+    """
+    Ensure the first argument is a container, and not a string.
+    """
+
+    def __init__(self, func):
+        update_wrapper(self, func)
+        self.func = func
+
+    def __get__(self, obj, objtype):
+        return partial(self.__call__, obj)
+
+    def __call__(self, cls, *args, **kwargs):
+        if "container" in kwargs:
+            kwargs["container"] = cls.get_container(kwargs["container"])
+        elif args:
+            container = cls.get_container(args[0])
+            args = (container, *args[1:])
+        return self.func(cls, *args, **kwargs)

--- a/oras/logger.py
+++ b/oras/logger.py
@@ -61,7 +61,7 @@ class ColorizingStreamHandler(_logging.StreamHandler):
         isatty = getattr(self.stream, "isatty", None)
         return isatty and isatty()  # type: ignore
 
-    def emit(self, record):
+    def emit(self, record: _logging.LogRecord):
         """
         Emit a log record
 
@@ -133,7 +133,7 @@ class Logger:
         for handler in self.log_handler:
             handler(msg)
 
-    def set_stream_handler(self, stream_handler):
+    def set_stream_handler(self, stream_handler: _logging.Handler):
         """
         Set a stream handler.
 

--- a/oras/schemas.py
+++ b/oras/schemas.py
@@ -22,6 +22,7 @@ layerProperties = {
         "mediaType": {"type": "string"},
         "size": {"type": "number"},
         "digest": {"type": "string"},
+        "annotations": annotations,
     },
 }
 
@@ -56,7 +57,6 @@ manifest = {
     "type": "object",
     "required": [
         "schemaVersion",
-        "mediaType",
         "config",
         "layers",
     ],

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -30,8 +30,6 @@ registry = f"{registry_host}:{registry_port}"
 target = f"{registry}/dinosaur/artifact:v1"
 target_dir = f"{registry}/dinosaur/directory:v1"
 
-# TODO test oras auth...
-
 
 def test_basic_oras(tmp_path):
     """
@@ -51,6 +49,12 @@ def test_basic_push_pull(tmp_path):
     assert os.path.exists(artifact)
     res = client.push(files=[artifact], target=target)
     assert res.status_code == 201
+
+    # Test getting tags
+    tags = client.get_tags(target)
+    for key in ["name", "tags"]:
+        assert key in tags
+    assert "v1" in tags["tags"]
 
     # Test pulling elsewhere
     files = client.pull(target=target, outdir=tmp_path)

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -28,7 +28,7 @@ def make_targz(source_dir: str, dest_name: Optional[str] = None) -> str:
     return dest_name
 
 
-def extract_targz(targz, outdir):
+def extract_targz(targz: str, outdir: str) -> str:
     """
     Extract a .tar.gz to an output directory.
     """

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,7 @@ for filename in $(find . -name "*.py" -not -path "*__init__.py" -not -path "./en
 done
 
 # mypy checks typing
-mypy oras
+mypy oras examples
 
 # isort (import order)
-isort --check-only *.py oras
+isort --check-only *.py oras examples


### PR DESCRIPTION
This PR is going to address PR review in #10, along with:

 - adding an example for a custom client (conda mirror) that has three artifacts in a manifest, and does custom parsing based on the content type.
 - adds a decorator ensure_container that allows for calling any registry function with a string container name OR already parsed container. 
 - add missing typing for Optional, etc.
 - adds an endpoint to retrieve tags metadata
 - Implements Layer as a class, still with NewLayer to instantiate and return the Layer.to_dict() if we want to skip having the class.
 - get_blob is now a public function
 - fixing a bug in the manifest schema validation

which were discussed in #11. Likely we will continue iterating on 11 to make it into more of a desired class with functions over a demo to show how things work!