### PR TITLE
updating oras project site metadata and disabling contributors workflow

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -3,7 +3,7 @@ name: Update Contributors
 on:
   push:
     branches:
-      - main
+      - doesnotexist
 
 jobs:
   Update:

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,30 +5,30 @@
 {# Extra custom things to the head HTML tag #}
 
 <!-- Social: Facebook / Open Graph -->
-<title>River Visualizations</title>
-<link rel="canonical" href="https://online-ml.github.io/viz/"/>
+<title>Oras Python</title>
+<link rel="canonical" href="https://oras-project.github.io/oras-py/"/>
 <meta property="og:type" content="website">
 
-<meta property="og:url" content="https://online-ml.github.io/viz/">
-<meta property="og:title" content="River Visualizations">
-<meta property="og:image" content="https://online-ml.github.io/viz/images/river_square.png">
-<meta property="og:description" content="River Visualization Examples">
-<meta property="og:site_name" content="River Visualizations">
+<meta property="og:url" content="https://oras-project.github.io/oras-py/">
+<meta property="og:title" content="Oras Python">
+<meta property="og:image" content="https://raw.githubusercontent.com/oras-project/oras-py/main/docs/images/oras.png">
+<meta property="og:description" content="OCI Registry as Storage (ORAS) in Python">
+<meta property="og:site_name" content="Oras Python">
 <meta property="og:locale" content="en_US">
 
 <!-- Social: Twitter -->
 <meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@MaxHalford">
-<meta name="twitter:title" content="Max Halford">
-<meta name="twitter:description" content="River Online Machine Learning">
-<meta name="twitter:image" content="https://online-ml.github.io/viz/images/river_square.png">
+<meta name="twitter:site" content="@orasproject">
+<meta name="twitter:title" content="ORAS">
+<meta name="twitter:description" content="OCI Registry as Storage (ORAS) in Python">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/oras-project/oras-py/main/docs/images/oras.png">
 
 <!-- Social: Google+ / Schema.org  -->
-<meta itemprop="name" content="River Visualizations">
-<meta itemprop="description" content="River Visualization Examples">
-<meta itemprop="image" content="https://online-ml.github.io/viz/images/river_square.png">
+<meta itemprop="name" content="Oras Python">
+<meta itemprop="description" content="OCI Registry as Storage (ORAS) in Python">
+<meta itemprop="image" content="https://raw.githubusercontent.com/oras-project/oras-py/main/docs/images/oras.png">
 <script type="application/ld+json">
-  {"@type":"WebSite","headline":"River Visualizations","url":"https://online-ml.github.io/viz","description":"River Visualization Examples","name":"River Visualizations","@context":"https://schema.org"}
+  {"@type":"WebSite","headline":"Oras Python","url":"https://oras-project.github.io/oras-py","description":"OCI Registry as Storage (ORAS) Python","name":"Oras Python","@context":"https://schema.org"}
 </script>
 {# Call the parent block #}
 {{ super() }}


### PR DESCRIPTION
the contributors workflow currently is done by a github bot and is not a signed commit so I am disabling it until we discuss!
I'm also update the docs site metadata to be for here - I used a template I made for River and just totally forgot it was there. :laughing: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>