### PR TITLE
adding 1_python.md site for oras-www

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Removing runtime dependency pytest-runner (0.0.12)
  - Adding authenticated login tests, fixing bugs with login/logout (0.0.11)
  - First draft release with basic functionality (0.0.1)
  - Initial skeleton of project (0.0.0)

--- a/docs/1_python.md
+++ b/docs/1_python.md
@@ -110,8 +110,8 @@ Note that oras-py will not remove content from your docker config files, so
 there is no concept of a "logout" unless you are using the client interactively,
 and have configs loaded, then you can do:
 
-```bash
-$ cli.logout(hostname)
+```python
+cli.logout(hostname)
 ```
 
 ### Push

--- a/docs/1_python.md
+++ b/docs/1_python.md
@@ -1,0 +1,197 @@
+# Oras Python User Guide
+
+Oras Python will allow you to run traditional push and pull commands for artifacts,
+or generate a custom client. This small user guide will walk you through these various
+steps, and please open an issue if functionality is missing.
+
+## Installation 
+
+### Pypi
+
+The module is available in pypi as [oras](https://pypi.org/project/oras/)
+and you can install as follows:
+
+```bash
+$ pip install oras
+``` 
+   
+You can also clone the repository and install locally:
+
+```bash
+$ git clone https://github.com/oras-project/oras-py
+$ cd oras-py
+$ pip install .
+``` 
+
+Or in development mode:
+
+```bash
+$ pip install -e .
+```
+
+Development mode means that the install is done from where you've cloned the library,
+so any changes you make are immediately "live" for testing.
+
+### Docker Container
+
+We provide a [Dockerfile](https://github.com/oras-project/oras-py/blob/main/Dockerfile) to build a container with the client.
+
+```bash
+$ docker build -t oras-py .
+
+$ docker run -it oras-py                                                                                                                   
+# which oras-py
+/opt/conda/bin/oras-py
+```
+
+## Registry
+
+You should see [supported registries](https://oras.land/implementors/#docker-distribution) or if you
+want to deploy a local testing registry (without auth), you can do:
+
+
+```bash
+$ docker run -it --rm -p 5000:5000 ghcr.io/oras-project/registry:latest
+```
+
+To test token authentication, you can either [set up your own auth server](https://github.com/adigunhammedolalekan/registry-auth)
+or just use an actual registry. The most we can do here is set up an example that uses basic auth.
+
+
+```bash
+# This is an htpassword file, "b" means bcrypt
+htpasswd -cB -b auth.htpasswd myuser mypass
+```
+
+> :warning: The server below will work to login with basic auth, but you won't be able to issue tokens.
+
+```bash
+# And start the registry with authentication
+docker run -it --rm -p 5000:5000 \
+    -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
+    -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
+    ghcr.io/oras-project/registry:latest
+```
+
+## Command Line
+
+### Login
+
+Once you create (or already have) a registry, you will want to login. You can do:
+
+```bash
+$ oras-py login -u myuser -p mypass localhost:5000
+
+# or localhost (insecure)
+$ oras-py login -u myuser -p mypass -k localhost:5000 --insecure
+
+WARNING! Using --password via the CLI is insecure. Use --password-stdin.
+Login Succeeded
+```
+
+You can also provide them interactively
+
+        
+```bash   
+$ oras-py login -k localhost:5000 --insecure
+Username: myuser
+Password: mypass
+Login Succeeded
+```
+
+or use `--password-stdin`
+
+```bash
+$ echo mypass | oras-py login -u myuser -k localhost:5000 --insecure --password-stdin
+Login Succeeded
+```
+
+Note that oras-py will not remove content from your docker config files, so
+there is no concept of a "logout" unless you are using the client interactively,
+and have configs loaded, then you can do:
+
+```bash
+$ cli.logout(hostname)
+```
+
+### Push
+
+Let's first push a container. Let's follow [the example here](https://oras.land/cli/1_pushing/):
+
+```bash
+echo "hello dinosaur" > artifact.txt
+$ oras-py push localhost:5000/dinosaur/artifact:v1 \
+--manifest-config /dev/null:application/vnd.acme.rocket.config \
+./artifact.txt
+Successfully pushed localhost:5000/dinosaur/artifact:v1
+```
+
+And if you aren't using https, add `--insecure`
+
+```bash
+$ oras-py push localhost:5000/dinosaur/artifact:v1 --insecure \
+--manifest-config /dev/null:application/vnd.acme.rocket.config \
+./artifact.txt
+Successfully pushed localhost:5000/dinosaur/artifact:v1
+```
+
+### Pull
+
+
+Now try a pull! We will first need to delete the file
+
+```bash
+$ rm -f artifact.txt # first delete the file
+$ oras-py pull localhost:5000/dinosaur/artifact:v1
+$ cat artifact.txt
+hello dinosaur
+```
+
+## Within Python
+
+If you want to use the library from within Python, here is how to do that.
+You'll still need a running registry as shown above. As a trick, if you want
+more detail than is available in these docs, you can peek into the
+[Python client code](https://github.com/oras-project/oras-py/tree/main/oras/cli).
+
+### Login and Logout
+
+```bash
+import oras.client
+client = oras.client.OrasClient()
+client.login(password="myuser", username="myuser", insecure=True)
+```
+
+And logout!
+        
+```bash
+client.logout("localhost:5000")   
+```
+
+### Push and Pull
+
+We are again following [the example here](https://oras.land/cli/1_pushing/).
+We are assuming an `artifact.txt` in the present working directory.
+
+
+```bash    
+client = oras.client.OrasClient(insecure=True)
+client.push(files=["artifact.txt"], target="localhost:5000/dinosaur/artifact:v1")
+Successfully pushed localhost:5000/dinosaur/artifact:v1
+Out[4]: <Response [201]>
+```
+
+And then pull!
+
+```bash
+res = client.pull(target="localhost:5000/dinosaur/artifact:v1")
+['/tmp/oras-tmp.e5itvzfi/artifact.txt']
+```
+
+
+## Custom Clients
+
+The benefit of Oras Python is that you can create a subclass that easily implements
+a registry, and then allows you to do custom interactions. We provide a few examples:
+
+ - [Conda Mirror](https://github.com/oras-project/oras-py/blob/main/examples/conda-mirror.py): an example to parse custom layers to retrieve metadata index.jsons (and archive) along with a binary to download.

--- a/oras/cli/__init__.py
+++ b/oras/cli/__init__.py
@@ -78,6 +78,7 @@ def get_parser():
         action="store_true",
     )
     pull.add_argument(
+        "-k",
         "--keep-old-files",
         help="do not overwrite existing files.",
         default=False,
@@ -131,7 +132,7 @@ def get_parser():
             help="registry password or identity token",
         )
         command.add_argument(
-            "-k",
+            "-i",
             "--insecure",
             dest="insecure",
             help="allow connections to SSL registry without certs",

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         keywords=KEYWORDS,
-        setup_requires=["pytest-runner"],
+        setup_requires=[],
         install_requires=INSTALL_REQUIRES,
         tests_require=TESTS_REQUIRES,
         extras_require={


### PR DESCRIPTION
What we can do here is add a page here, and then setup a workflow in oras-www to receive a dispatch event to do a build when it is triggered. I can first test this locally (and it will open a PR) and when we like that, we can add the dispatch event to be triggered in oras-py, and then push directly given that the commit is signed. Given that netlify is set up to build on push to main, if this
works it will mean that we always trigger an update and rebuild on oras-www when there is an update to oras-py.

So plan of action, more explicitly:

1. review and merge this page here
2. add a dispatch event to oras-www that will retrieve the updated file, put it where it needs to be, and pull request to main
3. test this with a local ping to see that it works
4. add the dispatch event to trigger from a merge to main for oras-py
5. when all that is working, change from PR to push
6. then update the oras-py docs to not include the redundant information and link to oras.land
 
Signed-off-by: vsoch <vsoch@users.noreply.github.com>