### PR TITLE
Docker optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - docker is an optional dependency, to minimize dependencies (0.0.12)
  - Adding authenticated login tests, fixing bugs with login/logout (0.0.11)
  - First draft release with basic functionality (0.0.1)
  - Initial skeleton of project (0.0.0)

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -21,8 +21,22 @@ You can also clone the repository and install locally:
     $ git clone https://github.com/oras-project/oras-py
     $ cd oras-py
     $ pip install .
+
+Note that we have several extra modes for installation:
+
+.. code:: console
+
+    # interactions are done via the docker client instead of manual
+    $ pip install oras[docker]
+
+    # Install dependencies for linting and tests
+    $ pip install oras[tests]
+    
+    # install everything
+    $ pip install oras[all]
+
  
-Or in development mode:
+Or in development mode, add ``-e``:
 
 .. code:: console
 

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -73,7 +73,7 @@ You can also provide them interactively
     Login Succeeded
 
 
-or use `--password-stdin`
+or use ``--password-stdin``
 
 .. code-block:: console
 

--- a/oras/auth.py
+++ b/oras/auth.py
@@ -18,10 +18,8 @@ def load_configs(configs: Optional[List[str]] = None):
     :param configs: list of configuration paths to load, defaults to None
     :type configs: optional list
     """
-    import docker
-
     configs = configs or []
-    default_config = docker.context.config.find_config_file()
+    default_config = oras.utils.find_docker_config()
 
     # Add the default docker config
     if default_config:

--- a/oras/main/login.py
+++ b/oras/main/login.py
@@ -36,11 +36,11 @@ class DockerClient:
         :type dockercfg_str: list
         """
         if not dockercfg_path:
-            dockercfg_path = os.path.expanduser("~/.docker/config.json")
-        if os.path.exists(dockercfg_path):
-            cfg = oras.utils.read_json(dockercfg_path)
+            dockercfg_path = oras.utils.find_docker_config(exists=False)
+        if os.path.exists(dockercfg_path): # type: ignore
+            cfg = oras.utils.read_json(dockercfg_path) # type: ignore
         else:
-            oras.utils.mkdir_p(os.path.dirname(dockercfg_path))
+            oras.utils.mkdir_p(os.path.dirname(dockercfg_path))  # type: ignore
             cfg = {"auths": {}}
         if registry in cfg["auths"]:
             cfg["auths"][registry]["auth"] = oras.auth.get_basic_auth(
@@ -50,7 +50,7 @@ class DockerClient:
             cfg["auths"][registry] = {
                 "auth": oras.auth.get_basic_auth(username, password)
             }
-        oras.utils.write_json(cfg, dockercfg_path)
+        oras.utils.write_json(cfg, dockercfg_path)  # type: ignore
         return {"Status": "Login Succeeded"}
 
 

--- a/oras/utils/__init__.py
+++ b/oras/utils/__init__.py
@@ -15,4 +15,4 @@ from .fileio import (
     write_file,
     write_json,
 )
-from .request import get_docker_client, iter_localhosts
+from .request import find_docker_config, get_docker_client, iter_localhosts

--- a/oras/utils/request.py
+++ b/oras/utils/request.py
@@ -2,6 +2,8 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import os
+
 
 def iter_localhosts(name: str):
     """
@@ -17,6 +19,17 @@ def iter_localhosts(name: str):
         names.append(name.replace("127.0.0.1", "localhost"))
     for name in names:
         yield name
+
+
+def find_docker_config(exists: bool = True):
+    """
+    Return the docker default config path.
+    """
+    path = os.path.expanduser("~/.docker/config.json")
+
+    # Allow the caller to request the path regardless of existing
+    if os.path.exists(path) or not exists:
+        return path
 
 
 def get_docker_client(insecure: bool = False, **kwargs):

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"
@@ -17,7 +17,6 @@ LICENSE = "LICENSE"
 INSTALL_REQUIRES = (
     ("jsonschema", {"min_version": None}),
     ("requests", {"min_version": None}),
-    ("docker", {"exact_version": "5.0.1"}),
 )
 
 TESTS_REQUIRES = (
@@ -28,4 +27,7 @@ TESTS_REQUIRES = (
     ("types-requests", {"min_version": None}),
     ("isort", {"min_version": None}),
 )
-INSTALL_REQUIRES_ALL = INSTALL_REQUIRES + TESTS_REQUIRES
+
+DOCKER_REQUIRES = (("docker", {"exact_version": "5.0.1"}),)
+
+INSTALL_REQUIRES_ALL = INSTALL_REQUIRES + TESTS_REQUIRES + DOCKER_REQUIRES

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
     INSTALL_REQUIRES = get_reqs(lookup)
     TESTS_REQUIRES = get_reqs(lookup, "TESTS_REQUIRES")
     INSTALL_REQUIRES_ALL = get_reqs(lookup, "INSTALL_REQUIRES_ALL")
+    DOCKER_REQUIRES = get_reqs(lookup, "DOCKER_REQUIRES")
 
     setup(
         name=NAME,
@@ -89,6 +90,7 @@ if __name__ == "__main__":
         extras_require={
             "all": [INSTALL_REQUIRES_ALL],
             "tests": [TESTS_REQUIRES],
+            "docker": [DOCKER_REQUIRES],
         },
         classifiers=[
             "Intended Audience :: Science/Research",


### PR DESCRIPTION
We currently are just using it for login and finding configs, and since osx on conda does not have it (and we want to support it) it makes sense to have docker be optional, meaning we fall back to manual ways to do the same thing. I am leaving it as an extra variant for now in case someone prefers using docker, however if we have confidence it is not needed it can be removed entirely.

See https://github.com/conda-forge/oras-py-feedstock/issues/1 and ping @wolfv 