### PR TITLE
Adding simple developer docs with example client

### DIFF
--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -31,8 +31,8 @@ Your most basic registry (that will mimic the default can be created like this:
         pass
 
 
-Interactions
-------------
+Pull Interactions
+-----------------
 
 You can imagine having a custom function that will retrieve a manifest or blob
 and do custom operations on it.
@@ -57,10 +57,120 @@ and do custom operations on it.
 
 Specifically the function ``self.get_blob`` will allow you to do that.
 
+
+Push Interactions
+-----------------
+
+You might instead want to have a custom lookup of archive paths and media types.
+Let's say we start with this:
+
+.. code-block:: python
+
+    {"/tmp/pakages-tmp.q6amnrkq/pakages-0.0.16.tar.gz": "application/vnd.oci.image.layer.v1.tar+gzip",
+     "/tmp/pakages-tmp.q6amnrkq/sbom.json": "application/vnd.cyclonedx"}
+
+Note that since paths are unique (and media types are not) we use that as the dictionary key.
+Here is how we might then create a custom Registry provider to handle:
+
+1. Creating layers from the blobs and media types
+2. Creating a manifest with the layers, and a config
+3. Uploading all of them
+
+This example is similar to what the ``oras.provider.Registry`` provides,
+but we are allowing better customization of content types and overriding the
+default "push" function.
+
+.. code-block:: python
+
+    import oras.oci
+    import oras.defaults
+    import oras.provider
+    from oras.decorator import ensure_container
+
+    import os
+    import sys
+
+    class Registry(oras.provider.Registry):
+        @ensure_container
+        def push(self, target, archives: dict, annotations=None):
+            """
+            Given a dict of layers (paths and corresponding mediaType) push.
+            """
+            # Prepare a new manifest
+            manifest = oras.oci.NewManifest()
+
+            # A lookup of annotations we can add
+            annotset = oras.oci.Annotations(annotations or {})
+
+            # Upload files as blobs
+            for blob, mediaType in archives.items():
+
+                # Must exist
+                if not os.path.exists(blob):
+                    sys.exit(f"{blob} does not exist.")
+
+                # Save directory or blob name before compressing
+                blob_name = os.path.basename(blob)
+
+                # If it's a directory, we need to compress
+                cleanup_blob = False
+                if os.path.isdir(blob):
+                    blob = oras.utils.make_targz(blob)
+                    cleanup_blob = True
+
+                # Create a new layer from the blob
+                layer = oras.oci.NewLayer(blob, mediaType, is_dir=cleanup_blob)
+                annotations = annotset.get_annotations(blob)
+                layer["annotations"] = {oras.defaults.annotation_title: blob_name}
+                if annotations:
+                    layer["annotations"].update(annotations)
+
+                # update the manifest with the new layer
+                manifest["layers"].append(layer)
+
+                # Upload the blob layer
+                response = self._upload_blob(blob, container, layer)
+                self._check_200_response(response)
+
+                # Do we need to cleanup a temporary targz?
+                if cleanup_blob and os.path.exists(blob):
+                    os.remove(blob)
+
+            # Add annotations to the manifest, if provided
+            manifest_annots = annotset.get_annotations("$manifest")
+            if manifest_annots:
+                manifest["annotations"] = manifest_annots
+
+            # Prepare the manifest config (temporary or one provided)
+            config_annots = annotset.get_annotations("$config")
+            conf, config_file = oras.oci.ManifestConfig()
+
+            # Config annotations?
+            if config_annots:
+                conf["annotations"] = config_annots
+
+            # Config is just another layer blob!
+            response = self._upload_blob(config_file, container, conf)
+            self._check_200_response(response)
+
+            # Final upload of the manifest
+            manifest["config"] = conf
+            self._check_200_response(self._upload_manifest(manifest, container))
+            print(f"Successfully pushed {container}")
+            return response
+
+
+The only difference between the above and the provided provider is that we are allowing
+more customization of the layers. The default oras client just assumes you have either
+a single layer or a compressed layer. Note that the decorator ``ensure_container``
+simply ensures that the target you provide as the first argument is properly parsed
+for the remainder of the function.
+
 Instantiate
 -----------
 
-Some registries may require authentiation:
+For both of the examples above, you might do the following.
+First, some registries may require authentiation:
 
 .. code-block:: python
 
@@ -78,8 +188,13 @@ And then you can run your custom functions after doing that.
 .. code-block:: python
 
     def main():
+        
+        # Pull Example
         reg = MyProvider()
         reg.set_basic_auth(user, token)
         reg.inspect("ghcr.io/wolfv/conda-forge/linux-64/xtensor:0.9.0-0")
 
-
+        # Push Example
+        reg = Registry()
+        reg.set_basic_auth(user, token)
+        reg.push("ghcr.io/vsoch/excellent-dinosaur:latest", archives)

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -62,12 +62,14 @@ Push Interactions
 -----------------
 
 You might instead want to have a custom lookup of archive paths and media types.
-Let's say we start with this:
+Let's say we start with this lookup, ``archives``:
 
 .. code-block:: python
 
-    {"/tmp/pakages-tmp.q6amnrkq/pakages-0.0.16.tar.gz": "application/vnd.oci.image.layer.v1.tar+gzip",
-     "/tmp/pakages-tmp.q6amnrkq/sbom.json": "application/vnd.cyclonedx"}
+    archives = {
+        "/tmp/pakages-tmp.q6amnrkq/pakages-0.0.16.tar.gz": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "/tmp/pakages-tmp.q6amnrkq/sbom.json": "application/vnd.cyclonedx"
+    }
 
 Note that since paths are unique (and media types are not) we use that as the dictionary key.
 Here is how we might then create a custom Registry provider to handle:
@@ -182,7 +184,9 @@ First, some registries may require authentiation:
         sys.exit("GITHUB_TOKEN and GITHUB_USER are required in the environment.")
 
 
-And then you can run your custom functions after doing that.
+And then you can run your custom functions after doing that, either inspecting
+a particular unique resource identifier or using your lookup of archives (paths
+and media types) to push:
 
 
 .. code-block:: python
@@ -197,4 +201,7 @@ And then you can run your custom functions after doing that.
         # Push Example
         reg = Registry()
         reg.set_basic_auth(user, token)
+        archives = {
+            "/tmp/pakages-tmp.q6amnrkq/pakages-0.0.16.tar.gz": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "/tmp/pakages-tmp.q6amnrkq/sbom.json": "application/vnd.cyclonedx"}
         reg.push("ghcr.io/vsoch/excellent-dinosaur:latest", archives)

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -92,7 +92,7 @@ default "push" function.
 
     class Registry(oras.provider.Registry):
         @ensure_container
-        def push(self, target, archives: dict, annotations=None):
+        def push(self, container, archives: dict, annotations=None):
             """
             Given a dict of layers (paths and corresponding mediaType) push.
             """
@@ -107,7 +107,7 @@ default "push" function.
 
                 # Must exist
                 if not os.path.exists(blob):
-                    sys.exit(f"{blob} does not exist.")
+                    logger.exit(f"{blob} does not exist.")
 
                 # Save directory or blob name before compressing
                 blob_name = os.path.basename(blob)
@@ -152,7 +152,7 @@ default "push" function.
             # Config is just another layer blob!
             response = self._upload_blob(config_file, container, conf)
             self._check_200_response(response)
-
+    
             # Final upload of the manifest
             manifest["config"] = conf
             self._check_200_response(self._upload_manifest(manifest, container))

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -70,6 +70,7 @@ class Layer:
         :param is_dir: is the blob a directory?
         :type is_dir: bool
         """
+        self.media_type = media_type
         if is_dir and not media_type:
             self.media_type = oras.defaults.default_blob_dir_media_type
         elif not is_dir and not media_type:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -294,6 +294,11 @@ class Registry:
         # Location should be in the header
         session_url = r.headers.get("location")
 
+        # Some registries do not return the full registry hostname
+        prefix = f"{self.prefix}://{container.registry}"
+        if not session_url.startswith(prefix):
+            session_url = f"{prefix}{session_url}"
+
         # Read the blob in chunks, for each do a patch
         start = 0
         with open(blob, "rb") as fd:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -287,7 +287,7 @@ class Registry:
         :type layer: dict
         """
         # Start an upload session
-        headers = {"Content-Type": "application/octet-stream", "Content-Length": 0}
+        headers = {"Content-Type": "application/octet-stream", "Content-Length": "0"}
         upload_url = f"{self.prefix}://{container.upload_blob_url()}"
         r = self.do_request(upload_url, "POST", headers=headers)
 

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -68,7 +68,7 @@ def test_basic_push_pull(tmp_path):
     assert os.path.exists(artifact)
 
     res = client.push(files=[artifact], target=target)
-    assert res.status_code == 201
+    assert res.status_code in [200, 201]
 
     # Test getting tags
     tags = client.get_tags(target)

--- a/oras/utils/__init__.py
+++ b/oras/utils/__init__.py
@@ -15,4 +15,4 @@ from .fileio import (
     write_file,
     write_json,
 )
-from .request import get_docker_client, iter_localhosts
+from .request import get_docker_client, iter_localhosts, append_url_params

--- a/oras/utils/request.py
+++ b/oras/utils/request.py
@@ -3,6 +3,10 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 
+import urllib.parse as urlparse
+from urllib.parse import urlencode
+
+
 def iter_localhosts(name: str):
     """
     Given a url with localhost, always resolve to 127.0.0.1.
@@ -17,6 +21,23 @@ def iter_localhosts(name: str):
         names.append(name.replace("127.0.0.1", "localhost"))
     for name in names:
         yield name
+
+
+def append_url_params(url: str, params: dict) -> str:
+    """
+    Given a dictionary of params and a url, parse the url and add extra params.
+
+    :param url: the url string to parse
+    :type url: str
+    :param params: parameters to add
+    :type params: dict
+    """
+    parts = urlparse.urlparse(url)
+    query = dict(urlparse.parse_qsl(parts.query))
+    query.update(params)
+    updated = list(parts)
+    updated[4] = urlencode(query)
+    return urlparse.urlunparse(updated)
 
 
 def get_docker_client(insecure: bool = False, **kwargs):


### PR DESCRIPTION
This PR aims to fix two issues that I just opened:

- #30 : a common use case is "I want to push these blobs with these custom media types) and since the current client is built around anticipating that we would eventually have different kinds of remotes/providers (right now there is just one) it probably needs to stay that way until we decide we aren't going to do this. However, using *args and **kwargs makes the interactions confusing at best. So for the being I think it's important we provide a simpler "these are my blobs and media types just push them!" example. This PR will add developer (Python API) docs that show how to do exactly this, over-riding the default push function.
- #31 since we always constrain an upload to be a single layer media type or compressed, we totally missed the third case of a custom media type, which I implemented in the example above. So this PR fixes that bug.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>