### PR TITLE
improving error message if location header missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - add debug if location header returned is empty (0.0.13)
  - docker is an optional dependency, to minimize dependencies (0.0.12)
    - Removing runtime dependency pytest-runner
    - bug fixes for GitHub packages

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -256,6 +256,10 @@ class Registry:
         :type container: oras.container.Container or str
         """
         try:
+            # Ensure output directory exists first
+            outdir = os.path.dirname(outfile)
+            if outdir and not os.path.exists(outdir):
+                oras.utils.mkdir_p(outdir)
             with self.get_blob(container, digest, stream=True) as r:
                 r.raise_for_status()
                 with open(outfile, "wb") as f:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -290,6 +290,8 @@ class Registry:
 
         # Location should be in the header
         session_url = self._get_location(r, container)
+        if not session_url:
+            logger.exit(f"Issue retrieving session url: {r.json()}")
 
         # PUT to upload blob url
         headers = {
@@ -352,6 +354,8 @@ class Registry:
 
         # Location should be in the header
         session_url = self._get_location(r, container)
+        if not session_url:
+            logger.exit(f"Issue retrieving session url: {r.json()}")
 
         # Read the blob in chunks, for each do a patch
         start = 0

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
currently if the location header is missing for any reason on a blob push (typically because auth is missing or wrong scope) a later error will trigger about an invalid url scheme, and this is misleading. We should check that the location is defined earlier on and provide a more meaningful message.

The test case I used to produce this was providing a token locally with the wrong scope - the request went through the auth flow (but was unsuccessful) and ultimately returned 403, and there was a meaningful message about the error in r.json().

Signed-off-by: vsoch <vsoch@users.noreply.github.com>