### PR TITLE
adding support for manifest --annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - support for adding one-off annotations for a manifest (0.0.14)
  - add debug if location header returned is empty (0.0.13)
  - docker is an optional dependency, to minimize dependencies (0.0.12)
    - Removing runtime dependency pytest-runner

--- a/docs/1_python.md
+++ b/docs/1_python.md
@@ -137,6 +137,37 @@ $ oras-py push localhost:5000/dinosaur/artifact:v1 --insecure \
 Successfully pushed localhost:5000/dinosaur/artifact:v1
 ```
 
+You can also provide an annotations file, which should be a lookup to an annotation set
+that corresponds with a particular file (absolute or relative path) or one of
+`$config` or `$manifest`. E.g.,:
+
+```python
+{"$manifest": {"manifest_annotation_key", "manifest_annotation_value"},
+ "$config": {"config_annotation_key", "config_annotation_value"},
+ "blob.tar.gz": {"blob_annotation_key", "blob_annotation_value"}}
+```
+
+Given this file, `annotations.json` you would provide to push as follows:
+
+```bash
+$ oras-py push localhost:5000/dinosaur/artifact:v1 --insecure \
+--annotation-file ./annotations.json \
+--manifest-config /dev/null:application/vnd.acme.rocket.config \
+./artifact.txt
+```
+
+As of version 0.0.14, you can also specify "one off" manifest annotations (e.g.,
+for the `$manifest` group). However, you are not allowed to define a `$manifest` key
+and one-off annotations (choose one or the other). Note that you can provide as many as you
+like, and each much be in the format `--annotation key1=value1` `--annotation key2=value2`:
+
+```bash
+$ oras-py push localhost:5000/dinosaur/artifact:v1 --insecure \
+--annotation key1=value1 --annotation key2=value2 \
+--manifest-config /dev/null:application/vnd.acme.rocket.config \
+./artifact.txt
+```
+
 ### Pull
 
 

--- a/docs/getting_started/developer-guide.md
+++ b/docs/getting_started/developer-guide.md
@@ -217,13 +217,20 @@ remainder of the function.
 For both of the examples above, you might do the following. First, some
 registries may require authentiation:
 
-``` python
+```python
 # We will need GitHub personal access token or token
 token = os.environ.get("GITHUB_TOKEN")
 user = os.environ.get("GITHUB_USER")
 
 if not token or not user:
     sys.exit("GITHUB_TOKEN and GITHUB_USER are required in the environment.")
+```
+
+And as a reminder, if you want to deploy a quick local registry (without auth)
+you can do:
+
+```bash
+$ docker run -it --rm -p 5000:5000 ghcr.io/oras-project/registry:latest
 ```
 
 And then you can run your custom functions after doing that, either

--- a/oras/cli/__init__.py
+++ b/oras/cli/__init__.py
@@ -89,7 +89,12 @@ def get_parser():
     pull.add_argument("--manifest-config-ref", help="manifest config reference")
 
     push = subparsers.add_parser("push", description=help.push_help)
-    push.add_argument("--manifest-annotations", help="manifest annotation file")
+    push.add_argument("--annotation-file", help="manifest annotation file")
+    push.add_argument(
+        "--annotation",
+        help="single manifest annotation (e.g., key=value)",
+        action="append",
+    )
     push.add_argument("--manifest-config", help="manifest config file")
     push.add_argument(
         "--disable-path-validation",

--- a/oras/cli/push.py
+++ b/oras/cli/push.py
@@ -2,10 +2,11 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-from oras.logger import logger
+import os
+
 import oras.client
 import oras.utils
-import os
+from oras.logger import logger
 
 
 def load_manifest_annotations(annotation_file, annotations):

--- a/oras/cli/push.py
+++ b/oras/cli/push.py
@@ -2,19 +2,55 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+from oras.logger import logger
 import oras.client
+import oras.utils
+import os
+
+
+def load_manifest_annotations(annotation_file, annotations):
+    """
+    Disambiguate annotations.
+    """
+    annotations = annotations or []
+    if annotation_file and not os.path.exists(annotation_file):
+        logger.exit(f"Annotation file {annotation_file} does not exist.")
+    if annotation_file:
+        lookup = oras.utils.read_json(annotation_file)
+
+        # not allowed to define both, mirroring oras-go
+        if "$manifest" in lookup and lookup["$manifest"]:
+            logger.exit(
+                "`--annotation` and `--annotation-file` with $manifest cannot be both specified."
+            )
+
+    # Finally, parse the list of annotations
+    parsed = {}
+    for annot in annotations:
+        if "=" not in annot:
+            logger.exit(
+                "Annotation {annot} invalid format, needs to be key=value pair."
+            )
+        key, value = annot.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
 
 
 def main(args, parser, extra, subparser):
     """
     A wrapper around an oras client push.
     """
+    manifest_annotations = load_manifest_annotations(
+        args.annotation_file, args.annotation
+    )
     client = oras.client.OrasClient(insecure=args.insecure)
     client.push(
         config_path=args.config,
         disable_path_validation=args.disable_path_validation,
         files=args.filerefs,
         manifest_config=args.manifest_config,
+        annotation_file=args.annotation_file,
+        manifest_annotations=manifest_annotations,
         username=args.username,
         password=args.password,
         quiet=args.quiet,

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -8,10 +8,10 @@ from typing import Dict, Optional, Tuple
 
 import jsonschema
 
-from oras.logger import logger
 import oras.defaults
 import oras.schemas
 import oras.utils
+from oras.logger import logger
 
 EmptyManifest = {
     "schemaVersion": 2,

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Tuple
 
 import jsonschema
 
+from oras.logger import logger
 import oras.defaults
 import oras.schemas
 import oras.utils
@@ -30,9 +31,19 @@ class Annotations:
         self.lookup = {}
         self.load(filename)
 
+    def add(self, section, key, value):
+        """
+        Add key/value pairs to a named section.
+        """
+        if section not in self.lookup:
+            self.lookup[section] = {}
+        self.lookup[section][key] = value
+
     def load(self, filename: str):
         if filename and os.path.exists(filename):
             self.lookup = oras.utils.read_json(filename)
+        if filename and not os.path.exists(filename):
+            logger.exit(f"Annotation file {filename} does not exist.")
 
     def get_annotations(self, section: str) -> dict:
         """

--- a/oras/tests/annotations.json
+++ b/oras/tests/annotations.json
@@ -1,0 +1,6 @@
+{
+	"$manifest": {
+		"holiday": "Christmas",
+		"candy": "candy-corn"
+	}
+}

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -6,8 +6,9 @@ import os
 import sys
 
 import pytest
-import oras.provider
+
 import oras.client
+import oras.provider
 import oras.utils
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -1,0 +1,81 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright The ORAS Authors."
+__license__ = "Apache-2.0"
+
+import os
+import sys
+
+import pytest
+import oras.provider
+import oras.client
+import oras.utils
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+registry_host = os.environ.get("ORAS_HOST")
+registry_port = os.environ.get("ORAS_PORT")
+with_auth = os.environ.get("ORAS_AUTH") == "true"
+oras_user = os.environ.get("ORAS_USER", "myuser")
+oras_pass = os.environ.get("ORAS_PASS", "mypass")
+
+
+def setup_module(module):
+    """
+    Ensure the registry port and host is in the environment.
+    """
+    if not registry_host or not registry_port:
+        sys.exit(
+            "You must export ORAS_HOST and ORAS_PORT for a running registry before running tests."
+        )
+    if with_auth and not oras_user or not oras_pass:
+        sys.exit("To test auth you need to export ORAS_USER and ORAS_PASS")
+
+
+registry = f"{registry_host}:{registry_port}"
+target = f"{registry}/dinosaur/artifact:v1"
+target_dir = f"{registry}/dinosaur/directory:v1"
+
+
+@pytest.mark.skipif(with_auth, reason="token auth is needed for push and pull")
+def test_annotated_registry_push(tmp_path):
+    """
+    Basic tests for oras push with annotations
+    """
+    # Direct access to registry functions
+    remote = oras.provider.Registry(hostname=registry, insecure=True)
+    client = oras.client.OrasClient(hostname=registry, insecure=True)
+    artifact = os.path.join(here, "artifact.txt")
+
+    assert os.path.exists(artifact)
+
+    # Custom manifest annotations
+    annots = {"holiday": "Halloween", "candy": "chocolate"}
+    res = client.push(files=[artifact], target=target, manifest_annotations=annots)
+    assert res.status_code in [200, 201]
+
+    # Get the manifest
+    manifest = remote.get_manifest(target)
+    assert "annotations" in manifest
+    for k, v in annots.items():
+        assert k in manifest["annotations"]
+        assert manifest["annotations"][k] == v
+
+    # Annotations from file with $manifest
+    annotation_file = os.path.join(here, "annotations.json")
+    file_annots = oras.utils.read_json(annotation_file)
+    assert "$manifest" in file_annots
+    res = client.push(files=[artifact], target=target, annotation_file=annotation_file)
+    assert res.status_code in [200, 201]
+    manifest = remote.get_manifest(target)
+
+    assert "annotations" in manifest
+    for k, v in file_annots["$manifest"].items():
+        assert k in manifest["annotations"]
+        assert manifest["annotations"][k] == v
+
+    # File that doesn't exist
+    annotation_file = os.path.join(here, "annotations-nope.json")
+    with pytest.raises(SystemExit):
+        res = client.push(
+            files=[artifact], target=target, annotation_file=annotation_file
+        )

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This will provide similar functionality to https://github.com/oras-project/oras/pull/468/files.

I made one change - I allow an annotation file and `--annotation` given that a `$manifest` isn't provided in the file, and we could go even further to just not allow overlapping variable names. I think the tool should be as flexible as possible to different developer needs, but without having any unexpected results.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>