### PR TITLE
Apply appropriate header for authentication against a gitlab registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Added expected header for authentication to gitlab registry (0.0.17)
  - safe extraction for targz extractions (0.0.16)
  - disable chunked upload for now (not supported by all registries) (0.0.15)
  - support for adding one-off annotations for a manifest (0.0.14)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -715,9 +715,12 @@ class Registry:
             )
             return False
 
+        params = {}
+
         # Prepare request to retry
         h = oras.auth.parse_auth_header(authHeaderRaw)
         if h.service:
+            params["service"] = h.service
             headers.update(
                 {
                     "Service": h.service,
@@ -730,8 +733,7 @@ class Registry:
         if not h.realm.startswith("http"):  # type: ignore
             h.realm = f"{self.prefix}://{h.realm}"
 
-        # If the www-authenticate included a scope, honor it!
-        params = {}
+        # If the www-authenticate included a scope, honor it!        
         if h.scope:
             params["scope"] = h.scope
 

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This adds a fix to set the `service=container_registry` to the request params rather than just headers. This is needed for gitlab registry authentication.

This is a simple fix for #49 , I don't know for certain if this may have negative impact for not gitlab registries.