### PR TITLE
replacing system exits with raising exceptions

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -2,4 +2,4 @@ pre-commit
 black
 isort
 flake8
-mypy
+mypy==0.961

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,12 @@ jobs:
         files: ./docs ./README.md
 
     - name: Lint Oras Python
+    - name: Setup Environment
+      run: conda create --quiet --name oras pre-commit
+    - name: Lint Oras Python
       run: |
+        export PATH="/usr/share/miniconda/bin:$PATH"
+        source activate oras
         make develop
         make lint
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,6 @@ jobs:
       with:
         files: ./docs ./README.md
 
-    - name: Lint Oras Python
     - name: Setup Environment
       run: conda create --quiet --name oras pre-commit
     - name: Lint Oras Python

--- a/.github/workflows/test-packages-deploy.yaml
+++ b/.github/workflows/test-packages-deploy.yaml
@@ -14,15 +14,23 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+      - name: Setup Environment
+        run: conda create --quiet --name oras requests
 
       - name: Install Oras Python
-        run: pip install -e .
+        run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate oras
+          pip install -e .
+
       - name: Test GitHub Packages Push/Pull
         env:
           user: ${{ github.actor }}
           token: ${{ secrets.GITHUB_TOKEN }}
           uri: ghcr.io/oras-project/oras-py/oras-py-test:latest
         run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate oras
           python setup.py sdist
           artifact=$(ls dist/*.tar.gz)
           echo ${token} | oras-py login -u ${user} ghcr.io --password-stdin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - logger should only exit in command line client, not in API (0.0.18)
+   - raising exceptions allows the calling using to catch the error
  - Added expected header for authentication to gitlab registry (0.0.17)
  - safe extraction for targz extractions (0.0.16)
  - disable chunked upload for now (not supported by all registries) (0.0.15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The versions coincide with releases on pip. Only major versions will be released
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
  - logger should only exit in command line client, not in API (0.0.18)
    - raising exceptions allows the calling using to catch the error
+   - support for requesting anonymous token from registry
  - Added expected header for authentication to gitlab registry (0.0.17)
  - safe extraction for targz extractions (0.0.16)
  - disable chunked upload for now (not supported by all registries) (0.0.15)

--- a/docs/getting_started/developer-guide.md
+++ b/docs/getting_started/developer-guide.md
@@ -87,7 +87,7 @@ make html
 After `make html` you can enter into `_build/html` and start a local web
 server to preview:
 
-``` console
+```console
 $ python -m http.server 9999
 ```
 
@@ -99,12 +99,46 @@ To render our Python API into the docs, we keep an updated restructured
 syntax in the `docs/source` folder that you can update on demand as
 follows:
 
-``` console
+```console
 $ ./apidoc.sh
 ```
 
 This should only be required if you change any docstrings or add/remove
 functions from oras-py source code.
+
+## Running Tests
+
+You'll want to create an environment to install to, and then install:
+
+```bash
+$ make install
+```
+
+You'll then want a registry running for the tests:
+
+```bash
+$ docker run -it --rm -p 5000:5000 ghcr.io/oras-project/registry:latest
+```
+
+And then when you run `make test`, the tests will run. This ultimately
+runs the file [scripts/test.sh](https://github.com/oras-project/oras-py/blob/main/scripts/test.sh).
+If you want to test interactively, add an IPython import statement somewhere in the tests:
+
+```bash
+# pip install IPython
+import IPython
+IPython.embed()
+```
+
+And then change the last line of the file to be:
+
+```diff
+- pytest oras/
++ pytest -xs oras/
+```
+
+And then you should be able to interactively run (and debug) the same tests
+that run in GitHub actions.
 
 ## Creating a Custom Client
 
@@ -280,9 +314,9 @@ you can do:
 $ docker run -it --rm -p 5000:5000 ghcr.io/oras-project/registry:latest
 ```
 
-And then you can run your custom functions after doing that, either
-inspecting a particular unique resource identifier or using your lookup
-of archives (paths and media types) to push:
+And add the `-d` for detached. Then you can run your custom functions after
+doing that, either inspecting a particular unique resource identifier or using
+your lookup of archives (paths and media types) to push:
 
 ``` python
 def main():

--- a/oras/cli/login.py
+++ b/oras/cli/login.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import oras.client
+from oras.logger import logger
 
 
 def main(args, parser, extra, subparser):
@@ -10,11 +11,14 @@ def main(args, parser, extra, subparser):
     Main is a light wrapper around the login command.
     """
     client = oras.client.OrasClient()
-    client.login(
-        password=args.password,
-        username=args.username,
-        config_path=args.config,
-        hostname=args.hostname,
-        insecure=args.insecure,
-        password_stdin=args.password_stdin,
-    )
+    try:
+        client.login(
+            password=args.password,
+            username=args.username,
+            config_path=args.config,
+            hostname=args.hostname,
+            insecure=args.insecure,
+            password_stdin=args.password_stdin,
+        )
+    except Exception as e:
+        logger.exit(str(e))

--- a/oras/cli/pull.py
+++ b/oras/cli/pull.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import oras.client
+from oras.logger import logger
 
 
 def main(args, parser, extra, subparser):
@@ -10,15 +11,18 @@ def main(args, parser, extra, subparser):
     A wrapper around an oras client pull.
     """
     client = oras.client.OrasClient(insecure=args.insecure)
-    client.pull(
-        config_path=args.config,
-        allowed_media_type=args.allowed_media_type
-        if not args.allow_all_media_types
-        else [],
-        overwrite=not args.keep_old_files,
-        manifest_config_ref=args.manifest_config_ref,
-        outdir=args.output,
-        password=args.password,
-        username=args.username,
-        target=args.target,
-    )
+    try:
+        client.pull(
+            config_path=args.config,
+            allowed_media_type=args.allowed_media_type
+            if not args.allow_all_media_types
+            else [],
+            overwrite=not args.keep_old_files,
+            manifest_config_ref=args.manifest_config_ref,
+            outdir=args.output,
+            password=args.password,
+            username=args.username,
+            target=args.target,
+        )
+    except Exception as e:
+        logger.exit(str(e))

--- a/oras/cli/push.py
+++ b/oras/cli/push.py
@@ -21,7 +21,7 @@ def load_manifest_annotations(annotation_file, annotations):
 
         # not allowed to define both, mirroring oras-go
         if "$manifest" in lookup and lookup["$manifest"]:
-            logger.exit(
+            raise ValueError(
                 "`--annotation` and `--annotation-file` with $manifest cannot be both specified."
             )
 
@@ -45,15 +45,18 @@ def main(args, parser, extra, subparser):
         args.annotation_file, args.annotation
     )
     client = oras.client.OrasClient(insecure=args.insecure)
-    client.push(
-        config_path=args.config,
-        disable_path_validation=args.disable_path_validation,
-        files=args.filerefs,
-        manifest_config=args.manifest_config,
-        annotation_file=args.annotation_file,
-        manifest_annotations=manifest_annotations,
-        username=args.username,
-        password=args.password,
-        quiet=args.quiet,
-        target=args.target,
-    )
+    try:
+        client.push(
+            config_path=args.config,
+            disable_path_validation=args.disable_path_validation,
+            files=args.filerefs,
+            manifest_config=args.manifest_config,
+            annotation_file=args.annotation_file,
+            manifest_annotations=manifest_annotations,
+            username=args.username,
+            password=args.password,
+            quiet=args.quiet,
+            target=args.target,
+        )
+    except Exception as e:
+        logger.exit(str(e))

--- a/oras/container.py
+++ b/oras/container.py
@@ -7,7 +7,6 @@ import re
 from typing import Optional
 
 import oras.defaults
-from oras.logger import logger
 
 docker_regex = re.compile(
     "(?:(?P<registry>[^/@]+[.:][^/@]*)/)?"
@@ -83,7 +82,7 @@ class Container:
         """
         match = re.search(docker_regex, name)
         if not match:
-            logger.exit(
+            raise ValueError(
                 f"{name} does not match a recognized registry unique resource identifier. Try <registry>/<namespace>/<repository>:<tag|digest>"
             )
         items = match.groupdict()  # type: ignore
@@ -95,7 +94,7 @@ class Container:
 
         # Repository and namespace are required
         if not self.repository or not self.namespace:
-            logger.exit(
+            raise ValueError(
                 "You are minimally required to include a <namespace>/<repository>"
             )
         self.namespace = self.namespace.strip("/")

--- a/oras/main/login.py
+++ b/oras/main/login.py
@@ -82,13 +82,13 @@ def login(
         if not username:
             password = input("Token: ")
             if not password:
-                logger.exit("token required")
+                raise ValueError("token required")
 
         # If we do have a username, we just need a passowrd
         else:
             password = input("Password: ")
             if not password:
-                logger.exit("password required")
+                raise ValueError("password required")
 
     else:
         logger.warning(

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -11,7 +11,6 @@ import jsonschema
 import oras.defaults
 import oras.schemas
 import oras.utils
-from oras.logger import logger
 
 EmptyManifest = {
     "schemaVersion": 2,
@@ -43,7 +42,7 @@ class Annotations:
         if filename and os.path.exists(filename):
             self.lookup = oras.utils.read_json(filename)
         if filename and not os.path.exists(filename):
-            logger.exit(f"Annotation file {filename} does not exist.")
+            raise FileNotFoundError(f"Annotation file {filename} does not exist.")
 
     def get_annotations(self, section: str) -> dict:
         """

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -784,4 +784,5 @@ class Registry:
         if token:
             self.headers.update({"Authorization": "Bearer %s" % token})
             self.token = token
-        return True
+            return True
+        return False

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -301,7 +301,7 @@ class Registry:
         # Location should be in the header
         session_url = self._get_location(r, container)
         if not session_url:
-            logger.exit(f"Issue retrieving session url: {r.json()}")
+            raise ValueError(f"Issue retrieving session url: {r.json()}")
 
         # PUT to upload blob url
         headers = {
@@ -365,7 +365,7 @@ class Registry:
         # Location should be in the header
         session_url = self._get_location(r, container)
         if not session_url:
-            logger.exit(f"Issue retrieving session url: {r.json()}")
+            raise ValueError(f"Issue retrieving session url: {r.json()}")
 
         # Read the blob in chunks, for each do a patch
         start = 0
@@ -404,7 +404,7 @@ class Registry:
         """
         if response.status_code not in [200, 201, 202]:
             self._parse_response_errors(response)
-            logger.exit(f"Issue with {response.request.url}:\n{response.reason}")
+            raise ValueError(f"Issue with {response.request.url}:\n{response.reason}")
 
     def _parse_response_errors(self, response: requests.Response):
         """
@@ -483,12 +483,12 @@ class Registry:
 
             # Must exist
             if not os.path.exists(blob):
-                logger.exit(f"{blob} does not exist.")
+                raise FileNotFoundError(f"{blob} does not exist.")
 
             # Path validation means blob must be relative to PWD.
             if validate_path:
                 if not self._validate_path(blob):
-                    logger.exit(
+                    raise ValueError(
                         f"Blob {blob} is not in the present working directory context."
                     )
 

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -86,7 +86,7 @@ def test_basic_push_pull(tmp_path):
     # Move artifact outside of context (should not work)
     moved_artifact = tmp_path / os.path.basename(artifact)
     shutil.copyfile(artifact, moved_artifact)
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         client.push(files=[moved_artifact], target=target)
 
     # This should work because we aren't checking paths

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -76,7 +76,7 @@ def test_annotated_registry_push(tmp_path):
 
     # File that doesn't exist
     annotation_file = os.path.join(here, "annotations-nope.json")
-    with pytest.raises(SystemExit):
+    with pytest.raises(FileNotFoundError):
         res = client.push(
             files=[artifact], target=target, annotation_file=annotation_file
         )

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -15,8 +15,6 @@ import tarfile
 import tempfile
 from typing import Generator, Optional, TextIO, Union
 
-from oras.logger import logger
-
 
 def make_targz(source_dir: str, dest_name: Optional[str] = None) -> str:
     """
@@ -63,18 +61,14 @@ def get_size(path: str) -> int:
 def get_file_hash(path: str, algorithm: str = "sha256") -> str:
     """
     Return an sha256 hash of the file based on an algorithm
+    Raises AttributeError if incorrect algorithm supplied.
 
     :param path: the path to get the size for
     :type path: str
     :param algorithm: the algorithm to use
     :type algorithm: str
     """
-    try:
-        hasher = getattr(hashlib, algorithm)()
-    except AttributeError:
-        logger.error("%s is an invalid algorithm.")
-        logger.exit(" ".join(hashlib.algorithms_guaranteed))
-
+    hasher = getattr(hashlib, algorithm)()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hasher.update(chunk)
@@ -94,7 +88,7 @@ def mkdir_p(path: str):
         if e.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:
-            logger.exit("Error creating path %s, exiting." % path)
+            raise ValueError(f"Error creating path {path}.")
 
 
 def get_tmpfile(

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Using the client within python should not exit, but instead raise an exception for the developer user to handle. This change removes system exits from the main API, and preserves them in only the command line client functions to provide a better user experience (a cleanly formatted error message instead of a stack trace). Specifically:

- logger.exit calls are replaced with exceptions
- I typically use `ValueError` for general or user errors, unless it's an obvious match like a `FileNotFoundError`
- calls to push/pull/login in a client function now try/catch the exceptions to print the message
- auth failures first try requesting anonymous token

There isn't an issue open for this, but pinging @prabhu to test. Note that some of the tests might expect the previous system exit so I'll wait for them to run and adjust appropriately.

This will close #56 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>