### PR TITLE
ensure we strip path separators from title push/pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - ensure we always strip path separators before pull/push (0.1.12)
  - exposing download_blob to the user since it uses streaming (0.1.11)
    - adding developer examples for pull.
    - start deprecation for _download_blob, _put_upload, _chunked_upload, _upload_manifest

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -525,6 +525,7 @@ import sys
 import oras.defaults
 import oras.oci
 import oras.provider
+import oras.utils
 from oras.decorator import ensure_container
 import logging
 
@@ -552,11 +553,11 @@ class Registry(oras.provider.Registry):
             # E.g., google.prices or google.prices-web or aws.prices
             if layer['mediaType'] == media_type:
 
-                # artifact path
+                # This annotation is currently the practice for a relative path to extract to
                 artifact = layer['annotations']['org.opencontainers.image.title']
 
-                # This annotation is currently the practice for a relative path to extract to
-                outfile = os.path.join(download_dir, artifact.strip(os.sep))
+                # This raises an error if there is a malicious path
+                outfile = oras.utils.sanitize_path(download_dir, os.path.join(download_dir, artifact))
 
                 # download blob ensures we stream, otherwise get_blob would return request
                 # this function also handles creating the output directory if does not exist

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -534,13 +534,16 @@ logger = logging.getLogger(__name__)
 class Registry(oras.provider.Registry):
 
     @ensure_container
-    def download_layer(self, download_dir, package, media_type):
+    def download_layers(self, download_dir, package, media_type):
         """
         Given a manifest of layers, retrieve a layer based on desired media type
         """
         # If you intend to call this function again, you might cache this response
         # for the package of interest.
         manifest = self.get_manifest(package)
+
+        # Let's return a list of download paths to the user
+        paths = []
 
         # Find the layer of interest! Currently we look for presence of the string
         # e.g., "prices" can come from "prices" or "prices-web"
@@ -557,7 +560,10 @@ class Registry(oras.provider.Registry):
 
                 # download blob ensures we stream, otherwise get_blob would return request
                 # this function also handles creating the output directory if does not exist
-                return self.download_blob(package, layer['digest'], outfile)
+                path = self.download_blob(package, layer['digest'], outfile)
+                paths.append(path)
+
+        return paths
 ```
 
 </details>

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -549,8 +549,11 @@ class Registry(oras.provider.Registry):
             # E.g., google.prices or google.prices-web or aws.prices
             if layer['mediaType'] == media_type:
 
+                # artifact path
+                artifact = layer['annotations']['org.opencontainers.image.title']
+
                 # This annotation is currently the practice for a relative path to extract to
-                outfile = os.path.join(download_dir, layer['annotations']['org.opencontainers.image.title'])
+                outfile = os.path.join(download_dir, artifact.strip(os.sep))
 
                 # download blob ensures we stream, otherwise get_blob would return request
                 # this function also handles creating the output directory if does not exist

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -564,7 +564,11 @@ class Registry:
             # Create a new layer from the blob
             layer = oras.oci.NewLayer(blob, is_dir=cleanup_blob, media_type=media_type)
             annotations = annotset.get_annotations(blob)
-            layer["annotations"] = {oras.defaults.annotation_title: blob_name}
+
+            # Always strip blob_name of path separator
+            layer["annotations"] = {
+                oras.defaults.annotation_title: blob_name.strip(os.sep)
+            }
             if annotations:
                 layer["annotations"].update(annotations)
 
@@ -648,7 +652,7 @@ class Registry:
             # If we don't have a filename, default to digest. Hopefully does not happen
             if not filename:
                 filename = layer["digest"]
-            outfile = os.path.join(outdir, filename)
+            outfile = os.path.join(outdir, filename.strip(os.sep))
             if not overwrite and os.path.exists(outfile):
                 logger.warning(
                     f"{outfile} already exists and --keep-old-files set, will not overwrite."

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -629,7 +629,7 @@ class Registry:
         :type allowed_media_type: list or None
         :param overwrite: if output file exists, overwrite
         :type overwrite: bool
-        :param manifest_config_ref: sav manifest config to this file
+        :param manifest_config_ref: save manifest config to this file
         :type manifest_config_ref: str
         :param outdir: output directory path
         :type outdir: str
@@ -652,7 +652,10 @@ class Registry:
             # If we don't have a filename, default to digest. Hopefully does not happen
             if not filename:
                 filename = layer["digest"]
-            outfile = os.path.join(outdir, filename.strip(os.sep))
+
+            # This raises an error if there is a malicious path
+            outfile = oras.utils.sanitize_path(outdir, os.path.join(outdir, filename))
+
             if not overwrite and os.path.exists(outfile):
                 logger.warning(
                     f"{outfile} already exists and --keep-old-files set, will not overwrite."

--- a/oras/utils/__init__.py
+++ b/oras/utils/__init__.py
@@ -13,6 +13,7 @@ from .fileio import (
     read_json,
     readline,
     recursive_find,
+    sanitize_path,
     workdir,
     write_file,
     write_json,

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -28,6 +28,20 @@ def make_targz(source_dir: str, dest_name: Optional[str] = None) -> str:
     return dest_name
 
 
+def sanitize_path(expected_dir, path):
+    """
+    Ensure a path resolves to be in the expected parent directory.
+
+    It can be directly there or a child, but not outside it.
+    We raise an error if it does not - this should not happen
+    """
+    base_dir = pathlib.Path(expected_dir)
+    test_path = (base_dir / path).resolve()
+    if not base_dir.resolve() in test_path.resolve().parents:
+        raise Exception(f"Filename {test_path} is not in {base_dir} directory")
+    return str(test_path.resolve())
+
+
 @contextmanager
 def workdir(dirname):
     """

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
I am also changing the example to return multiple paths (assuming there are multiple layers of the same content type, which seems possible!)

Signed-off-by: vsoch <vsoch@users.noreply.github.com>