### PR TITLE
chore: move Josh Dolitsky to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @vsoch @jdolitsky @stevelasker
+* @vsoch @stevelasker

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -2,5 +2,7 @@
 
 Owners:
   - Vanessasaurus (@vsoch)
-  - Josh Dolitsky (@jdolitsky)
   - Steve Lasker (@stevelasker)
+
+Emeritus:
+  - Josh Dolitsky (@jdolitsky)


### PR DESCRIPTION
Move Josh Dolitsky (@jdolitsky) to emeritus (as requested by https://github.com/oras-project/community/issues/32)