### PR TITLE
Ensure basic auth when getting manifest

### DIFF
--- a/oras/provider.py
+++ b/oras/provider.py
@@ -110,6 +110,7 @@ class Registry:
             elif not auth:
                 return False
             self._basic_auth = auth
+            self.set_header("Authorization", "Basic %s" % self._basic_auth)
             return True
         return False
 
@@ -791,6 +792,7 @@ class Registry:
         if not allowed_media_type:
             allowed_media_type = [oras.defaults.default_manifest_media_type]
         headers = {"Accept": ";".join(allowed_media_type)}
+        headers.update(self.headers)
 
         get_manifest = f"{self.prefix}://{container.manifest_url()}"  # type: ignore
         response = self.do_request(get_manifest, "GET", headers=headers)


### PR DESCRIPTION
Include basic auth header when getting manifest, avoiding login failure with Nexus OSS repo.

Nexus OSS responds `Sonatype Nexus Repository Manager` as realm in the `WWW-Authenticate` header and does not play well with current implementation. However, getting a token should not be necessary with basic auth enabled. Go oras client works well already.

**Current behavior**

Targeting same nexus repository, that does not allow anonymous manifest/pull and requires basic auth.

_oras CLI_
```
oras pull my-nexus.example.com/my/image.db:latest
Downloading 394458a69d7a image.db
Downloaded  394458a69d7a image.db
Pulled my-nexus.example.com/my/image.db:latest
Digest: sha256:56d0ba1e3806f3af6b75d88eab8fe82f83d66b899e06efcda8d4eefa07b66e38
```

_Test client_
```
import logging
import oras.client

HOST='my-nexus.example.com'
IMG='my/image.db:latest'

logging.basicConfig(level=logging.DEBUG)

client = oras.client.OrasClient(hostname=HOST, insecure=False)
client.pull(target=IMG)
```

_oras-py (with test client)_
```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): my-nexus.example.com:443
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
INFO:oras.logger:Retrying in 3 seconds - error: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
INFO:oras.logger:Retrying in 5 seconds - error: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
INFO:oras.logger:Retrying in 11 seconds - error: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
INFO:oras.logger:Retrying in 29 seconds - error: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
INFO:oras.logger:Retrying in 83 seconds - error: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
DEBUG:urllib3.connectionpool:Resetting dropped connection: my-nexus.example.com
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 401 113
DEBUG:oras.logger:No Authorization, requesting anonymous token
DEBUG:oras.logger:Final params are {}
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/tst/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/home/tst/oras-fork/test.py", line 10, in <module>
    client.pull(target=IMG)
  File "/home/tst/oras-fork/oras/client.py", line 137, in pull
    return self.remote.pull(*args, **kwargs)
  File "/home/tst/oras-fork/oras/provider.py", line 741, in pull
    manifest = self.get_manifest(container, allowed_media_type)
  File "/home/tst/oras-fork/oras/decorator.py", line 35, in __call__
    return self.func(cls, *args, **kwargs)
  File "/home/tst/oras-fork/oras/provider.py", line 796, in get_manifest
    response = self.do_request(get_manifest, "GET", headers=headers)
  File "/home/tst/oras-fork/oras/decorator.py", line 60, in __call__
    return self.func(cls, *args, **kwargs)
  File "/home/tst/oras-fork/oras/provider.py", line 845, in do_request
    if self.authenticate_request(response):
  File "/home/tst/oras-fork/oras/provider.py", line 901, in authenticate_request
    if self.request_anonymous_token(h):
  File "/home/tst/oras-fork/oras/provider.py", line 965, in request_anonymous_token
    response = self.session.request("GET", h.realm, params=params)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "/usr/lib/python3/dist-packages/requests/models.py", line 316, in prepare
    self.prepare_url(url, params)
  File "/usr/lib/python3/dist-packages/requests/models.py", line 390, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL 'Sonatype Nexus Repository Manager': No schema supplied. Perhaps you meant http://Sonatype Nexus Repository Manager?
```

_oras-py (with test client) in this patch_
```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): my-nexus.example.com:443
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/manifests/latest HTTP/1.1" 200 513
DEBUG:urllib3.connectionpool:https://my-nexus.example.com:443 "GET /v2/my/image.db/blobs/sha256:394458a69d7a4beb146fbeed181b6646b2dfb583df1b8fc5f71ada8034eb7726 HTTP/1.1" 200 809119
INFO:oras.logger:Successfully pulled /tmp/oras-tmp.4tafaoj1/image.db.
```