### PR TITLE
Updated Broken ORAS image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-![https://raw.githubusercontent.com/oras-project/oras-www/main/docs/assets/images/oras.png](https://raw.githubusercontent.com/oras-project/oras-www/main/docs/assets/images/oras.png)
+![https://github.com/oras-project/oras-www/blob/main/static/img/oras.png](https://github.com/oras-project/oras-www/blob/main/static/img/oras.png)
 
 OCI Registry as Storage enables libraries to push OCI Artifacts to [OCI Conformant](https://github.com/opencontainers/oci-conformance) registries. This is a Python SDK for Python developers to empower them to do this in their applications.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-![https://github.com/oras-project/oras-www/blob/main/static/img/oras.png](https://github.com/oras-project/oras-www/blob/main/static/img/oras.png)
+![ORAS Logo](https://raw.githubusercontent.com/oras-project/oras-www/main/static/img/oras.png)
 
 OCI Registry as Storage enables libraries to push OCI Artifacts to [OCI Conformant](https://github.com/opencontainers/oci-conformance) registries. This is a Python SDK for Python developers to empower them to do this in their applications.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Oras Python
 
-![Oras Python Logo](https://github.com/oras-project/oras-www/blob/main/static/img/oras.png)
+![Oras Python Logo](https://github.com/oras-project/oras-py/blob/main/docs/images/oras.png)
 
 Welcome to Oras Python!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Oras Python
 
-![Oras Python Logo](https://github.com/oras-project/oras-py/blob/main/docs/images/oras.png)
+![Oras Python Logo](https://raw.githubusercontent.com/oras-project/oras-py/main/docs/images/oras.png)
 
 Welcome to Oras Python!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Oras Python
 
-![Oras Python Logo](https://raw.githubusercontent.com/oras-project/oras-www/main/docs/assets/images/oras.png)
+![Oras Python Logo](https://github.com/oras-project/oras-www/blob/main/static/img/oras.png)
 
 Welcome to Oras Python!
 


### PR DESCRIPTION
The old link pointing to oras.png is broken and giving a 404 error.
So, updated the ORAS image link with the new link that points to oras.png .