### PR TITLE
Fix issue 93 Windows blob upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+  - patch fix for blob upload Windows, closes issue [93](https://github.com/oras-project/oras-py/issues/93) (0.1.19)
   - patch fix for empty manifest config on Windows, closes issue [90](https://github.com/oras-project/oras-py/issues/90) (0.1.18)
   - patch fix to correct session url pattern, closes issue [78](https://github.com/oras-project/oras-py/issues/78) (0.1.17)
   - add support for tag deletion and retry decorators (0.1.16)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -17,6 +17,7 @@ import oras.oci
 import oras.schemas
 import oras.utils
 from oras.logger import logger
+from oras.utils.fileio import PathAndOptionalContent
 
 # container type can be string or container
 container_type = Union[str, oras.container.Container]
@@ -179,10 +180,10 @@ class Registry:
         :return - A Tuple of the path and the content-type, using the default unknown
                   config media type if none found in the reference
         """
-        ref, content = oras.utils.split_path_and_content(ref)
-        if not content:
-            content = oras.defaults.unknown_config_media_type
-        return ref, content
+        path_content: PathAndOptionalContent = oras.utils.split_path_and_content(ref)
+        if not path_content.content:
+            path_content.content = oras.defaults.unknown_config_media_type
+        return path_content.path, path_content.content
 
     def upload_blob(
         self,
@@ -640,7 +641,11 @@ class Registry:
         # Upload files as blobs
         for blob in kwargs.get("files", []):
             # You can provide a blob + content type
-            blob, media_type = oras.utils.split_path_and_content(str(blob))
+            path_content: PathAndOptionalContent = oras.utils.split_path_and_content(
+                str(blob)
+            )
+            blob = path_content.path
+            media_type = path_content.content
 
             # Must exist
             if not os.path.exists(blob):

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -164,9 +164,9 @@ class Registry:
         """
         return os.getcwd() in os.path.abspath(path)
 
-    def _parse_manifest_ref(self, ref: str) -> Union[Tuple[str, str], List[str]]:
+    def _parse_manifest_ref(self, ref: str) -> Tuple[str, str]:
         """
-        Parse an optional manifest config, e.g:
+        Parse an optional manifest config.
 
         Examples
         --------
@@ -176,10 +176,13 @@ class Registry:
 
         :param ref: the manifest reference to parse (examples above)
         :type ref: str
+        :return - A Tuple of the path and the content-type, using the default unknown
+                  config media type if none found in the reference
         """
-        if ":" not in ref:
-            return ref, oras.defaults.unknown_config_media_type
-        return ref.split(":", 1)
+        ref, content = oras.utils.split_path_and_content(ref)
+        if not content:
+            content = oras.defaults.unknown_config_media_type
+        return ref, content
 
     def upload_blob(
         self,
@@ -637,8 +640,7 @@ class Registry:
         # Upload files as blobs
         for blob in kwargs.get("files", []):
             # You can provide a blob + content type
-            if ":" in str(blob):
-                blob, media_type = str(blob).split(":", 1)
+            blob, media_type = oras.utils.split_path_and_content(str(blob))
 
             # Must exist
             if not os.path.exists(blob):

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -8,9 +8,9 @@ import sys
 import pytest
 
 import oras.client
+import oras.defaults
 import oras.provider
 import oras.utils
-import oras.defaults
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -87,7 +87,7 @@ def test_parse_manifest():
     """
     Test parse manifest function.
 
-    Parse manifest function has additional logic for Windows - this isn't included in 
+    Parse manifest function has additional logic for Windows - this isn't included in
     these tests as they don't usually run on Windows.
     """
     testref = "path/to/config:application/vnd.oci.image.config.v1+json"

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -10,6 +10,7 @@ import pytest
 import oras.client
 import oras.provider
 import oras.utils
+import oras.defaults
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -80,3 +81,38 @@ def test_annotated_registry_push(tmp_path):
         res = client.push(
             files=[artifact], target=target, annotation_file=annotation_file
         )
+
+
+def test_parse_manifest():
+    """
+    Test parse manifest function.
+
+    Parse manifest function has additional logic for Windows - this isn't included in 
+    these tests as they don't usually run on Windows.
+    """
+    testref = "path/to/config:application/vnd.oci.image.config.v1+json"
+    remote = oras.provider.Registry(hostname=registry, insecure=True)
+    ref, content_type = remote._parse_manifest_ref(testref)
+    assert ref == "path/to/config"
+    assert content_type == "application/vnd.oci.image.config.v1+json"
+
+    testref = "path/to/config:application/vnd.oci.image.config.v1+json:extra"
+    remote = oras.provider.Registry(hostname=registry, insecure=True)
+    ref, content_type = remote._parse_manifest_ref(testref)
+    assert ref == "path/to/config"
+    assert content_type == "application/vnd.oci.image.config.v1+json:extra"
+
+    testref = "/dev/null:application/vnd.oci.image.manifest.v1+json"
+    ref, content_type = remote._parse_manifest_ref(testref)
+    assert ref == "/dev/null"
+    assert content_type == "application/vnd.oci.image.manifest.v1+json"
+
+    testref = "/dev/null"
+    ref, content_type = remote._parse_manifest_ref(testref)
+    assert ref == "/dev/null"
+    assert content_type == oras.defaults.unknown_config_media_type
+
+    testref = "path/to/config.json"
+    ref, content_type = remote._parse_manifest_ref(testref)
+    assert ref == "path/to/config.json"
+    assert content_type == oras.defaults.unknown_config_media_type

--- a/oras/tests/test_utils.py
+++ b/oras/tests/test_utils.py
@@ -107,26 +107,26 @@ def test_print_json():
 def test_split_path_and_content():
     """
     Test split path and content function.
-    
+
     Function has additional logic for Windows - this isn't included in these tests as
     they don't usually run on Windows.
-    """    
+    """
     testref = "path/to/config:application/vnd.oci.image.config.v1+json"
-    ref, content_type = utils.split_path_and_content(testref)
-    assert ref == "path/to/config"
-    assert content_type == "application/vnd.oci.image.config.v1+json"
+    path_content = utils.split_path_and_content(testref)
+    assert path_content.path == "path/to/config"
+    assert path_content.content == "application/vnd.oci.image.config.v1+json"
 
     testref = "/dev/null:application/vnd.oci.image.config.v1+json"
-    ref, content_type = utils.split_path_and_content(testref)
-    assert ref == "/dev/null"
-    assert content_type == "application/vnd.oci.image.config.v1+json"
+    path_content = utils.split_path_and_content(testref)
+    assert path_content.path == "/dev/null"
+    assert path_content.content == "application/vnd.oci.image.config.v1+json"
 
     testref = "/dev/null"
-    ref, content_type = utils.split_path_and_content(testref)
-    assert ref == "/dev/null"
-    assert not content_type
+    path_content = utils.split_path_and_content(testref)
+    assert path_content.path == "/dev/null"
+    assert not path_content.content
 
     testref = "path/to/config.json"
-    ref, content_type = utils.split_path_and_content(testref)
-    assert ref == "path/to/config.json"
-    assert not content_type
+    path_content = utils.split_path_and_content(testref)
+    assert path_content.path == "path/to/config.json"
+    assert not path_content.content

--- a/oras/tests/test_utils.py
+++ b/oras/tests/test_utils.py
@@ -102,3 +102,31 @@ def test_print_json():
     print("Testing utils.print_json")
     result = utils.print_json({1: 1})
     assert result == '{\n    "1": 1\n}'
+
+
+def test_split_path_and_content():
+    """
+    Test split path and content function.
+    
+    Function has additional logic for Windows - this isn't included in these tests as
+    they don't usually run on Windows.
+    """    
+    testref = "path/to/config:application/vnd.oci.image.config.v1+json"
+    ref, content_type = utils.split_path_and_content(testref)
+    assert ref == "path/to/config"
+    assert content_type == "application/vnd.oci.image.config.v1+json"
+
+    testref = "/dev/null:application/vnd.oci.image.config.v1+json"
+    ref, content_type = utils.split_path_and_content(testref)
+    assert ref == "/dev/null"
+    assert content_type == "application/vnd.oci.image.config.v1+json"
+
+    testref = "/dev/null"
+    ref, content_type = utils.split_path_and_content(testref)
+    assert ref == "/dev/null"
+    assert not content_type
+
+    testref = "path/to/config.json"
+    ref, content_type = utils.split_path_and_content(testref)
+    assert ref == "path/to/config.json"
+    assert not content_type

--- a/oras/utils/__init__.py
+++ b/oras/utils/__init__.py
@@ -14,6 +14,7 @@ from .fileio import (
     readline,
     recursive_find,
     sanitize_path,
+    split_path_and_content,
     workdir,
     write_file,
     write_json,

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Fix for https://github.com/oras-project/oras-py/issues/93

Tested on Linux by writing unit test for parse_manifest and running it before and after change.
Tested on Window by trying to upload a blob with the path C:\blah\blah.json - failed before the fix, succeeds afterwards.