### PR TITLE
Distinguish between insecure and tis-verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
-- add tls_verify to provider class for optional disable tls verification (0.1.22)
+ - add tls_verify to provider class for optional disable tls verification (0.1.22)
  - Allow to pull exactly to PWD (0.1.21)
  - Ensure insecure is passed to provider class (0.1.20)
  - patch fix for blob upload Windows, closes issue [93](https://github.com/oras-project/oras-py/issues/93) (0.1.19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+- add tls_verify to provider class for optional disable tls verification (0.1.22)
  - Allow to pull exactly to PWD (0.1.21)
  - Ensure insecure is passed to provider class (0.1.20)
  - patch fix for blob upload Windows, closes issue [93](https://github.com/oras-project/oras-py/issues/93) (0.1.19)

--- a/oras/client.py
+++ b/oras/client.py
@@ -30,6 +30,7 @@ class OrasClient:
         hostname: Optional[str] = None,
         registry: Optional[oras.provider.Registry] = None,
         insecure: bool = False,
+        tls_verify: bool = True,
     ):
         """
         Create an ORAS client.
@@ -43,7 +44,7 @@ class OrasClient:
         :param insecure: use http instead of https
         :type insecure: bool
         """
-        self.remote = registry or oras.provider.Registry(hostname, insecure)
+        self.remote = registry or oras.provider.Registry(hostname, insecure, tls_verify)
 
     def __repr__(self) -> str:
         return str(self)
@@ -142,6 +143,7 @@ class OrasClient:
         password: str,
         password_stdin: bool = False,
         insecure: bool = False,
+        tls_verify: bool = True,
         hostname: Optional[str] = None,
         config_path: Optional[List[str]] = None,
     ) -> dict:
@@ -158,6 +160,8 @@ class OrasClient:
         :type password_stdin: bool
         :param insecure: use http instead of https
         :type insecure: bool
+        :param tls_verify: verify tls
+        :type tls_verify: bool
         :param hostname: the hostname to login to
         :type hostname: str
         :param config_path: list of config paths to add
@@ -170,7 +174,7 @@ class OrasClient:
             username=username,
             password=password,
             password_stdin=password_stdin,
-            insecure=insecure,
+            tls_verify=tls_verify,
             hostname=hostname,
             config_path=config_path,  # type: ignore
         )
@@ -189,7 +193,7 @@ class OrasClient:
         username: Optional[str] = None,
         password: Optional[str] = None,
         password_stdin: bool = False,
-        insecure: bool = False,
+        tls_verify: bool = True,
         hostname: Optional[str] = None,
         config_path: Optional[str] = None,
     ) -> dict:
@@ -224,7 +228,7 @@ class OrasClient:
         # Login
         # https://docker-py.readthedocs.io/en/stable/client.html?highlight=login#docker.client.DockerClient.login
         try:
-            client = oras.utils.get_docker_client(insecure=insecure)
+            client = oras.utils.get_docker_client(tls_verify=tls_verify)
             return client.login(
                 username=username,
                 password=password,

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -56,7 +56,7 @@ class Registry:
         self._basic_auth = None
         self._tls_verify = tls_verify
 
-        if insecure:
+        if not tls_verify:
             requests.packages.urllib3.disable_warnings()  # type: ignore
 
     def logout(self, hostname: str):

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -31,7 +31,12 @@ class Registry:
     and the registry isn't necessarily the "remote" endpoint.
     """
 
-    def __init__(self, hostname: Optional[str] = None, insecure: bool = False):
+    def __init__(
+        self,
+        hostname: Optional[str] = None,
+        insecure: bool = False,
+        tls_verify: bool = True,
+    ):
         """
         Create a new registry provider.
 
@@ -39,6 +44,8 @@ class Registry:
         :type hostname: str
         :param insecure: use http instead of https
         :type insecure: bool
+        :param tls_verify: verify TLS certificates
+        :type tls_verify: bool
         """
         self.hostname: Optional[str] = hostname
         self.headers: dict = {}
@@ -47,7 +54,7 @@ class Registry:
         self.token: Optional[str] = None
         self._auths: dict = {}
         self._basic_auth = None
-        self._insecure = insecure
+        self._tls_verify = tls_verify
 
         if insecure:
             requests.packages.urllib3.disable_warnings()  # type: ignore
@@ -846,7 +853,7 @@ class Registry:
             json=json,
             headers=headers,
             stream=stream,
-            verify=not self._insecure,
+            verify=self._tls_verify,
         )
 
         # A 401 response is a request for authentication

--- a/oras/utils/request.py
+++ b/oras/utils/request.py
@@ -51,13 +51,13 @@ def append_url_params(url: str, params: dict) -> str:
     return urlparse.urlunparse(updated)
 
 
-def get_docker_client(insecure: bool = False, **kwargs):
+def get_docker_client(tls_verify: bool = True, **kwargs):
     """
     Get a docker client.
 
-    :param tls : enable tls
-    :type tls: bool
+    :param tls_verify : enable tls
+    :type tls_verify: bool
     """
     import docker
 
-    return docker.DockerClient(tls=not insecure, **kwargs)
+    return docker.DockerClient(tls=tls_verify, **kwargs)

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
The insecure option for oras.registry sets the transport protocol. The default behaviour of other projects which interact with registries (ores-cli, podman,....),  differenciate between transport protocol and trust for connections to registries.
To avoid breaking changes, the parameter `insecure` sets the transport protocol ans the new parameter `tls_verify` sets verification on CA Trust.