### PR TITLE
sanitize paths should be allowed to place something in the same pwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
-  - Ensure insecure is passed to provider class (0.1.20)
-  - patch fix for blob upload Windows, closes issue [93](https://github.com/oras-project/oras-py/issues/93) (0.1.19)
-  - patch fix for empty manifest config on Windows, closes issue [90](https://github.com/oras-project/oras-py/issues/90) (0.1.18)
-  - patch fix to correct session url pattern, closes issue [78](https://github.com/oras-project/oras-py/issues/78) (0.1.17)
-  - add support for tag deletion and retry decorators (0.1.16)
+ - Allow to pull exactly to PWD (0.1.21)
+ - Ensure insecure is passed to provider class (0.1.20)
+ - patch fix for blob upload Windows, closes issue [93](https://github.com/oras-project/oras-py/issues/93) (0.1.19)
+ - patch fix for empty manifest config on Windows, closes issue [90](https://github.com/oras-project/oras-py/issues/90) (0.1.18)
+ - patch fix to correct session url pattern, closes issue [78](https://github.com/oras-project/oras-py/issues/78) (0.1.17)
+ - add support for tag deletion and retry decorators (0.1.16)
  - bugfix that pagination sets upper limit of 10K (0.1.15)
  - pagination for tags (and general function for pagination) (0.1.14)
  - expose upload_blob function to be consistent (0.1.13)

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -43,6 +43,9 @@ def sanitize_path(expected_dir, path):
     It can be directly there or a child, but not outside it.
     We raise an error if it does not - this should not happen
     """
+    # It's OK to pull to PWD exactly
+    if os.path.abspath(expected_dir) == os.path.abspath(path):
+        return os.path.abspath(expected_dir)
     base_dir = pathlib.Path(expected_dir)
     test_path = (base_dir / path).resolve()
     if not base_dir.resolve() in test_path.resolve().parents:

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.20"
+__version__ = "0.1.21"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
problem: currently extracting to the PWD does not work because sanitize paths is expecting the extraction to always be in a subdirectory. Solution: allow them to be the same.