### PR TITLE
Removing the additional duplicate sub-directory from sanitize_path()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - eliminate the additional subdirectory creation while pulling an image to a custom output directory (0.1.24)
   - patch fix for pulling artifacts by digest (0.1.23)
     - patch fix to reject cookies as this could trigger registries into handling the lib as a web client
     - patch fix for proper validation and specification of the subject element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
  - eliminate the additional subdirectory creation while pulling an image to a custom output directory (0.1.24)
-  - patch fix for pulling artifacts by digest (0.1.23)
+   - updating the exclude string in the pyproject.toml file to match the [data type black expects](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format)
+ - patch fix for pulling artifacts by digest (0.1.23)
     - patch fix to reject cookies as this could trigger registries into handling the lib as a web client
     - patch fix for proper validation and specification of the subject element
  - add tls_verify to provider class for optional disable tls verification (0.1.22)

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -122,18 +122,36 @@ def test_parse_manifest():
 def test_sanitize_path():
     HOME_DIR = str(Path.home())
     assert str(oras.utils.sanitize_path(HOME_DIR, HOME_DIR)) == f"{HOME_DIR}"
-    assert str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, "username"))) == f"{HOME_DIR}/username"
-    assert str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, ".", "username"))) == f"{HOME_DIR}/username"
+    assert (
+        str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, "username")))
+        == f"{HOME_DIR}/username"
+    )
+    assert (
+        str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, ".", "username")))
+        == f"{HOME_DIR}/username"
+    )
 
     with pytest.raises(Exception) as e:
         assert oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, ".."))
-    assert str(e.value) == f"Filename {Path(os.path.join(HOME_DIR, '..')).resolve()} is not in {HOME_DIR} directory"
+    assert (
+        str(e.value)
+        == f"Filename {Path(os.path.join(HOME_DIR, '..')).resolve()} is not in {HOME_DIR} directory"
+    )
 
     assert oras.utils.sanitize_path("", "") == str(Path(".").resolve())
-    assert oras.utils.sanitize_path("/opt", os.path.join("/opt", "image_name")) == str(Path("/opt/image_name").resolve())
+    assert oras.utils.sanitize_path("/opt", os.path.join("/opt", "image_name")) == str(
+        Path("/opt/image_name").resolve()
+    )
     assert oras.utils.sanitize_path("/../../", "/") == str(Path("/").resolve())
-    assert oras.utils.sanitize_path(Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..")) == str(Path("..").resolve())
+    assert oras.utils.sanitize_path(
+        Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..")
+    ) == str(Path("..").resolve())
 
     with pytest.raises(Exception) as e:
-        assert oras.utils.sanitize_path(Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..", "..")) != str(Path("../..").resolve())
-    assert str(e.value) == f"Filename {Path(os.path.join(os.getcwd(), '..', '..')).resolve()} is not in {Path('../').resolve()} directory"
+        assert oras.utils.sanitize_path(
+            Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..", "..")
+        ) != str(Path("../..").resolve())
+    assert (
+        str(e.value)
+        == f"Filename {Path(os.path.join(os.getcwd(), '..', '..')).resolve()} is not in {Path('../').resolve()} directory"
+    )

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -4,6 +4,7 @@ __license__ = "Apache-2.0"
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -116,3 +117,23 @@ def test_parse_manifest():
     ref, content_type = remote._parse_manifest_ref(testref)
     assert ref == "path/to/config.json"
     assert content_type == oras.defaults.unknown_config_media_type
+
+
+def test_sanitize_path():
+    HOME_DIR = str(Path.home())
+    assert str(oras.utils.sanitize_path(HOME_DIR, HOME_DIR)) == f"{HOME_DIR}"
+    assert str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, "username"))) == f"{HOME_DIR}/username"
+    assert str(oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, ".", "username"))) == f"{HOME_DIR}/username"
+
+    with pytest.raises(Exception) as e:
+        assert oras.utils.sanitize_path(HOME_DIR, os.path.join(HOME_DIR, ".."))
+    assert str(e.value) == f"Filename {Path(os.path.join(HOME_DIR, '..')).resolve()} is not in {HOME_DIR} directory"
+
+    assert oras.utils.sanitize_path("", "") == str(Path(".").resolve())
+    assert oras.utils.sanitize_path("/opt", os.path.join("/opt", "image_name")) == str(Path("/opt/image_name").resolve())
+    assert oras.utils.sanitize_path("/../../", "/") == str(Path("/").resolve())
+    assert oras.utils.sanitize_path(Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..")) == str(Path("..").resolve())
+
+    with pytest.raises(Exception) as e:
+        assert oras.utils.sanitize_path(Path(os.getcwd()).parent.absolute(), os.path.join(os.getcwd(), "..", "..")) != str(Path("../..").resolve())
+    assert str(e.value) == f"Filename {Path(os.path.join(os.getcwd(), '..', '..')).resolve()} is not in {Path('../').resolve()} directory"

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -43,14 +43,11 @@ def sanitize_path(expected_dir, path):
     It can be directly there or a child, but not outside it.
     We raise an error if it does not - this should not happen
     """
-    # It's OK to pull to PWD exactly
-    if os.path.abspath(expected_dir) == os.path.abspath(path):
-        return os.path.abspath(expected_dir)
-    base_dir = pathlib.Path(expected_dir)
-    test_path = (base_dir / path).resolve()
-    if not base_dir.resolve() in test_path.resolve().parents:
-        raise Exception(f"Filename {test_path} is not in {base_dir} directory")
-    return str(test_path.resolve())
+    base_dir = pathlib.Path(expected_dir).expanduser().resolve()
+    path = pathlib.Path(path).expanduser().resolve() # path = base_dir + file_name
+    if not ((base_dir in path.parents) or (str(base_dir) == str(path))):
+        raise Exception(f"Filename {path} is not in {base_dir} directory")
+    return str(path)
 
 
 @contextmanager

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -44,7 +44,7 @@ def sanitize_path(expected_dir, path):
     We raise an error if it does not - this should not happen
     """
     base_dir = pathlib.Path(expected_dir).expanduser().resolve()
-    path = pathlib.Path(path).expanduser().resolve() # path = base_dir + file_name
+    path = pathlib.Path(path).expanduser().resolve()  # path = base_dir + file_name
     if not ((base_dir in path.parents) or (str(base_dir) == str(path))):
         raise Exception(f"Filename {path} is not in {base_dir} directory")
     return str(path)

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.23"
+__version__ = "0.1.24"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 profile = "black"
-exclude = ["^env/"]
+exclude = '^env/'
 
 [tool.isort]
 profile = "black" # needed for black/isort compatibility


### PR DESCRIPTION
The existing implementation adds an additional sub-directory with the same name when an image is pulled and is stored explicitly to a custom output directory. This happens because the "test_path" variable [appends](https://github.com/oras-project/oras-py/blob/main/oras/utils/fileio.py#L50) "path" to "base_dir" wherein the ["path" variable itself is base_dir + filename](https://github.com/oras-project/oras-py/blob/main/oras/provider.py#L794). This commit fixes this problem.