### PR TITLE
bug with .tar.gz upload - name needs .tar.gz in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - name of uploaded archive must be .tar.gz to be extracted as such with oras go (0.1.26)
  - refactor tests using fixtures and rework pre-commit configuration (0.1.25)
  - eliminate the additional subdirectory creation while pulling an image to a custom output directory (0.1.24)
    - updating the exclude string in the pyproject.toml file to match the [data type black expects](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -699,11 +699,21 @@ class Registry:
             annotations = annotset.get_annotations(blob)
 
             # Always strip blob_name of path separator
-            layer["annotations"] = {
-                oras.defaults.annotation_title: blob_name.strip(os.sep)
-            }
+            if cleanup_blob:  # is_dir
+                layer["annotations"] = {
+                    oras.defaults.annotation_title: blob_name.strip(os.sep) + ".tar.gz"
+                }
+            else:
+                layer["annotations"] = {
+                    oras.defaults.annotation_title: blob_name.strip(os.sep)
+                }
+
             if annotations:
                 layer["annotations"].update(annotations)
+
+            import IPython
+
+            IPython.embed()
 
             # update the manifest with the new layer
             manifest["layers"].append(layer)

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
There is a bug with the title that, given it does not have .tar.gz with the oras-go client, it will not be extracted as such.