### PR TITLE
Allow uploading when  `config_manifest` is not specified in the google artifact registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - To make it available for more OCI registries, the value of config used when `manifest_config` is not specified in `client.push()` has been changed from a pure empty string to `{}` (0.1.26)
  - refactor tests using fixtures and rework pre-commit configuration (0.1.25)
  - eliminate the additional subdirectory creation while pulling an image to a custom output directory (0.1.24)
    - updating the exclude string in the pyproject.toml file to match the [data type black expects](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format)

--- a/oras/defaults.py
+++ b/oras/defaults.py
@@ -41,3 +41,8 @@ default_blocksize = 32768
 
 # what you get for a blank digest, so we don't need to save and recalculate
 blank_hash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# what you get for a blank config digest, so we don't need to save and recalculate
+blank_config_hash = (
+    "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+)

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -117,7 +117,7 @@ def NewLayer(
 
 def ManifestConfig(
     path: Optional[str] = None, media_type: Optional[str] = None
-) -> Tuple[Dict[str, object], str]:
+) -> Tuple[Dict[str, object], Optional[str]]:
     """
     Write an empty config, if one is not provided
 
@@ -128,11 +128,11 @@ def ManifestConfig(
     """
     # Create an empty config if we don't have one
     if not path or not os.path.exists(path):
-        path = os.devnull
+        path = None
         conf = {
             "mediaType": media_type or oras.defaults.unknown_config_media_type,
-            "size": 0,
-            "digest": oras.defaults.blank_hash,
+            "size": 2,
+            "digest": oras.defaults.blank_config_hash,
         }
 
     else:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -7,6 +7,7 @@ import os
 import urllib
 from dataclasses import asdict, dataclass
 from http.cookiejar import DefaultCookiePolicy
+from tempfile import TemporaryDirectory
 from typing import Callable, List, Optional, Tuple, Union
 
 import jsonschema
@@ -747,7 +748,15 @@ class Registry:
 
         # Config is just another layer blob!
         logger.debug(f"Preparing config {conf}")
-        response = self.upload_blob(config_file, container, conf)
+        if config_file is None:
+            with TemporaryDirectory() as tmp:
+                config_file = os.path.join(tmp, "config.json")
+                with open(config_file, "w") as f:
+                    f.write("{}")
+                response = self.upload_blob(config_file, container, conf)
+        else:
+            response = self.upload_blob(config_file, container, conf)
+
         self._check_200_response(response)
 
         # Final upload of the manifest

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -7,7 +7,6 @@ import os
 import urllib
 from dataclasses import asdict, dataclass
 from http.cookiejar import DefaultCookiePolicy
-from tempfile import TemporaryDirectory
 from typing import Callable, List, Optional, Tuple, Union
 
 import jsonschema
@@ -749,13 +748,10 @@ class Registry:
         # Config is just another layer blob!
         logger.debug(f"Preparing config {conf}")
         if config_file is None:
-            with TemporaryDirectory() as tmp:
-                config_file = os.path.join(tmp, "config.json")
-                with open(config_file, "w") as f:
-                    f.write("{}")
-                response = self.upload_blob(config_file, container, conf)
-        else:
-            response = self.upload_blob(config_file, container, conf)
+            config_file = oras.utils.get_tmpfile(suffix=".json")
+            with open(config_file, "w") as f:
+                f.write("{}")
+        response = self.upload_blob(config_file, container, conf)
 
         self._check_200_response(response)
 

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -5,9 +5,11 @@ __license__ = "Apache-2.0"
 import copy
 import os
 import urllib
+from contextlib import contextmanager, nullcontext
 from dataclasses import asdict, dataclass
 from http.cookiejar import DefaultCookiePolicy
-from typing import Callable, List, Optional, Tuple, Union
+from tempfile import TemporaryDirectory
+from typing import Callable, Generator, List, Optional, Tuple, Union
 
 import jsonschema
 import requests
@@ -23,6 +25,14 @@ from oras.utils.fileio import PathAndOptionalContent
 
 # container type can be string or container
 container_type = Union[str, oras.container.Container]
+
+
+@contextmanager
+def temporary_empty_config() -> Generator[str, None, None]:
+    with TemporaryDirectory() as tmpdir:
+        config_file = oras.utils.get_tmpfile(tmpdir=tmpdir, suffix=".json")
+        oras.utils.write_file(config_file, "{}")
+        yield config_file
 
 
 @dataclass
@@ -747,11 +757,10 @@ class Registry:
 
         # Config is just another layer blob!
         logger.debug(f"Preparing config {conf}")
-        if config_file is None:
-            config_file = oras.utils.get_tmpfile(suffix=".json")
-            with open(config_file, "w") as f:
-                f.write("{}")
-        response = self.upload_blob(config_file, container, conf)
+        with temporary_empty_config() if config_file is None else nullcontext(
+            config_file
+        ) as config_file:
+            response = self.upload_blob(config_file, container, conf)
 
         self._check_200_response(response)
 

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
#112 

The issue causing errors in Google Artifact Registry when no config_manifest was specified has been resolved.

I could not reproduce this problem with the test method shown in the [Developer's Guide](https://oras-project.github.io/oras-py/getting_started/developer-guide.html#documentation), but I have confirmed that it is resolved in my own environment.


