### PR TITLE
Add preset headers to get_manifest request

### DIFF
--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-black==23.3.0
+black==24.1.0
 isort
 flake8
 mypy==0.961

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,16 +8,17 @@ jobs:
   generate-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: gh-pages
 
-    - name: Create conda environment
-      run: conda create --quiet -c conda-forge --name oraspy
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
 
     - name: Install Oras and Dependencies
       run: |
-        export PATH="/usr/share/miniconda/bin:$PATH"
         root=$PWD
         source activate oraspy
         cd /tmp

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,6 @@ jobs:
     - name: Install Oras and Dependencies
       run: |
         root=$PWD
-        source activate oraspy
         cd /tmp
         git clone https://github.com/oras-project/oras-py
         cd oras-py

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,18 +6,21 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check Spelling
       uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
       with:
         files: ./docs ./README.md
 
-    - name: Setup Environment
-      run: conda create --quiet --name oras pre-commit
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
     - name: Lint Oras Python
       run: |
-        export PATH="/usr/share/miniconda/bin:$PATH"
-        source activate oras
+        python --version
+        python3 -m pip install pre-commit
+        python3 -m pip install black
         make develop
         make lint
 
@@ -30,16 +33,15 @@ jobs:
         - 5000:5000
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Environment
-      run: conda create --quiet --name oras requests
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
     - name: Test Oras Python
       env:
         registry_host: localhost
         registry_port: ${{ job.services.registry.ports[5000] }}
         REGISTRY_STORAGE_DELETE_ENABLED: "true"
       run: |
-        export PATH="/usr/share/miniconda/bin:$PATH"
-        source activate oras
-        pip install --upgrade pip setuptools
         make install
         make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,15 +10,14 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Install
-      run: conda create --quiet --name oras twine
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
 
     - name: Install dependencies
       run: |
-        export PATH="/usr/share/miniconda/bin:$PATH"
-        source activate oras
         pip install -e .
         pip install setuptools wheel twine
     - name: Build and publish
@@ -26,7 +25,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USER }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
       run: |
-        export PATH="/usr/share/miniconda/bin:$PATH"
-        source activate oras
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Tributors Update
       uses: con/tributors@master
       env:
@@ -68,7 +68,7 @@ jobs:
         echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
 
     - name: Open Pull Request
-      uses: vsoch/pull-request-action@50f22f6d146226ee6b73b7a001f26a3d4579f360 # 1.0.22
+      uses: vsoch/pull-request-action@master
       if: ${{ env.OPEN_PULL_REQUEST == '1' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Introduce the option to not refresh headers when fetching manifests when pulling artifacts (0.1.27)
  - To make it available for more OCI registries, the value of config used when `manifest_config` is not specified in `client.push()` has been changed from a pure empty string to `{}` (0.1.26)
  - refactor tests using fixtures and rework pre-commit configuration (0.1.25)
  - eliminate the additional subdirectory creation while pulling an image to a custom output directory (0.1.24)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -843,6 +843,7 @@ class Registry:
         if not allowed_media_type:
             allowed_media_type = [oras.defaults.default_manifest_media_type]
         headers = {"Accept": ";".join(allowed_media_type)}
+        headers.update(self.headers)
 
         get_manifest = f"{self.prefix}://{container.manifest_url()}"  # type: ignore
         response = self.do_request(get_manifest, "GET", headers=headers)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -757,8 +757,10 @@ class Registry:
 
         # Config is just another layer blob!
         logger.debug(f"Preparing config {conf}")
-        with temporary_empty_config() if config_file is None else nullcontext(
-            config_file
+        with (
+            temporary_empty_config()
+            if config_file is None
+            else nullcontext(config_file)
         ) as config_file:
             response = self.upload_blob(config_file, container, conf)
 
@@ -835,7 +837,10 @@ class Registry:
 
     @decorator.ensure_container
     def get_manifest(
-        self, container: container_type, allowed_media_type: Optional[list] = None, refresh_headers: bool = True
+        self,
+        container: container_type,
+        allowed_media_type: Optional[list] = None,
+        refresh_headers: bool = True,
     ) -> dict:
         """
         Retrieve a manifest for a package.
@@ -850,7 +855,7 @@ class Registry:
         if not allowed_media_type:
             allowed_media_type = [oras.defaults.default_manifest_media_type]
         headers = {"Accept": ";".join(allowed_media_type)}
-        
+
         if not refresh_headers:
             headers.update(self.headers)
 

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.26"
+__version__ = "0.1.27"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Currently when making the request to get manifests, previously set headers are ignored and only the Allowed media type headers are passed to `do_request`.

I have a scenario where I set the Bearer token in the client using `self._client.set_token_auth(token)`

However, the call for `get_manifest` fails as the Authorization header is not passed. It falls back to using Basic authentication in `do_request`, which fails because my registry only support token authentication.