### PR TITLE
docs: use valid media_type format in examples

### DIFF
--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -132,7 +132,7 @@ import oras.defaults
 
 layers = []
 for blob in blobs:
-    layer = oras.oci.NewLayer(blob, is_dir=False, media_type="org.dinosaur.tools.blobish")
+    layer = oras.oci.NewLayer(blob, is_dir=False, media_type="application/x-org.dinosaur.tools.blobish")
 
     # This is important so oras clients can derive the relative name you want to download to
     # Using basename assumes a flat directory of files - it doesn't have to be.
@@ -390,7 +390,7 @@ class Registry(oras.provider.Registry):
 
             blob = item.get("path")
             media_type = (
-                item.get("media_type") or "org.dinosaur.tool.datatype"
+                item.get("media_type") or "application/x-org.dinosaur.tool.datatype"
             )
             annots = item.get("annotations") or {}
 
@@ -464,7 +464,7 @@ def push(uri, root):
     for filename in os.listdir(root):
 
         # use some logic here to derive the mediaType
-        media_type = "org.dinosaur.tool.datatype"
+        media_type = "application/x-org.dinosaur.tool.datatype"
 
         # Add some custom annotations!
         size = os.path.getsize(os.path.join(root, filename))  # bytes


### PR DESCRIPTION
Hi 👋 
proposing with this PR to make documentation media_type examples adhere to the MIME type/Media Type format specification.

Some OCI registry (such as Zot) seems to me they enable by default the validation of media-type according to the standard.
The current examples in the doc don't respect the standard, making the examples fail at runtime.
e.g.
```
{"level":"error","error":"[layers.0.mediaType: Does not match pattern '^[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}$']","goroutine":242,"caller":"zotregistry.dev/zot/pkg/storage/common/common.go:87","time":"2024-06-05T14:26:36.160643+02:00","message":"failed to validate OCIv1 image manifest schema"}
```

The proposed modification in this PR make use of media_type examples which adhere to the MIME type/Media Type format spec, thus avoiding the validation error from the server/OCI registry side.