### PR TITLE
chore: fix typing for manifest_config param of push fn

### DIFF
--- a/oras/provider.py
+++ b/oras/provider.py
@@ -678,7 +678,7 @@ class Registry:
         config_path: Optional[str] = None,
         disable_path_validation: bool = False,
         files: Optional[List] = None,
-        manifest_config: Optional[dict] = None,
+        manifest_config: Optional[str] = None,
         annotation_file: Optional[str] = None,
         manifest_annotations: Optional[dict] = None,
         subject: Optional[str] = None,


### PR DESCRIPTION
for push() the parameter `manifest_config` seems to me has the wrong type annotation.

https://github.com/oras-project/oras-py/blob/9527aa1665fe435c44221fedf94b704612a82ca5/oras/provider.py#L681

while it should be an `Optional[str]`

considering it's used in push() to be passed to _parse_manifest_ref()

https://github.com/oras-project/oras-py/blob/9527aa1665fe435c44221fedf94b704612a82ca5/oras/provider.py#L785-L786

which expect a `str` (and not a `dict`)

https://github.com/oras-project/oras-py/blob/9527aa1665fe435c44221fedf94b704612a82ca5/oras/provider.py#L228-L246

hope this helps :)

