### PR TITLE
fix(core): provider do_request to maintain verify in all request, basic headers

### DIFF
--- a/.github/workflows/auth-tests.yaml
+++ b/.github/workflows/auth-tests.yaml
@@ -23,9 +23,13 @@ jobs:
           registry_port: 5000
           with_auth: true
           REGISTRY_AUTH: "{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}"
+          REGISTRY_HTTP_TLS_CERTIFICATE: "/etc/docker/registry/server.cert"
+          REGISTRY_HTTP_TLS_KEY: "/etc/docker/registry/server.key"
           REGISTRY_STORAGE_DELETE_ENABLED: "true"
         run: |
            htpasswd -cB -b auth.htpasswd myuser mypass
            cp auth.htpasswd /etc/docker/registry/auth.htpasswd
+           apk add openssl
+           openssl req -newkey rsa:4096 -nodes -sha256 -keyout /etc/docker/registry/server.key -x509 -days 365 -subj "/C=IT/ST=Lombardy/L=Milan/O=Acme Org/OU=IT Department/CN=example.com" -out /etc/docker/registry/server.cert
            registry serve /etc/docker/registry/config.yml & sleep 5
            echo $PWD && ls $PWD && make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
- - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers (0.2.0)
  - refactor of auth to be provided by backend modules (0.2.0)
+   - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers
  - Allow generating a Subject from a pre-existing Manifest (0.1.30)
  - add option to not refresh headers during the pushing flow, useful for push with basic auth (0.1.29)
  - enable additionalProperties in schema validation (0.1.28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers (0.2.0)
  - refactor of auth to be provided by backend modules (0.2.0)
  - Allow generating a Subject from a pre-existing Manifest (0.1.30)
  - add option to not refresh headers during the pushing flow, useful for push with basic auth (0.1.29)

--- a/oras/auth/basic.py
+++ b/oras/auth/basic.py
@@ -39,4 +39,8 @@ class BasicAuth(AuthBackend):
         :param originalResponse: original response to get the Www-Authenticate header
         :type originalResponse: requests.Response
         """
-        return self.get_auth_header(), True
+        result = {}
+        if headers is not None:
+            result.update(headers)
+        result.update(self.get_auth_header())
+        return result, True

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -950,6 +950,7 @@ class Registry:
             json=json,
             headers=headers,
             stream=stream,
+            verify=self._tls_verify,
         )
 
         # One retry if 403 denied (need new token?)
@@ -957,11 +958,14 @@ class Registry:
             headers, changed = self.auth.authenticate_request(
                 response, headers, refresh=True
             )
-        return self.session.request(
-            method,
-            url,
-            data=data,
-            json=json,
-            headers=headers,
-            stream=stream,
-        )
+            response = self.session.request(
+                method,
+                url,
+                data=data,
+                json=json,
+                headers=headers,
+                stream=stream,
+                verify=self._tls_verify,
+            )
+
+        return response

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -146,7 +146,7 @@ def test_directory_push_pull_selfsigned_auth(
     Test push and pull for directory using a self-signed cert registry (`tls_verify=False`) and basic auth (`auth_backend="basic"`)
     """
     client = oras.client.OrasClient(
-        hostname=registry, tls_verify=False, auth_backend="basic"
+        hostname=registry, insecure=True, tls_verify=False, auth_backend="basic"
     )
     res = client.login(
         hostname=registry,

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -146,7 +146,7 @@ def test_directory_push_pull_selfsigned_auth(
     Test push and pull for directory using a self-signed cert registry (`tls_verify=False`) and basic auth (`auth_backend="basic"`)
     """
     client = oras.client.OrasClient(
-        hostname=registry, insecure=True, tls_verify=False, auth_backend="basic"
+        hostname=registry, tls_verify=False, auth_backend="basic"
     )
     res = client.login(
         hostname=registry,

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -151,6 +151,7 @@ def test_directory_push_pull_selfsigned_auth(
     )
     res = client.login(
         hostname=registry,
+        tls_verify=False,
         username=credentials.user,
         password=credentials.password,
     )

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -136,3 +136,33 @@ def test_directory_push_pull(tmp_path, registry, credentials, target_dir):
     assert str(tmp_path) in files[0]
     assert os.path.exists(files[0])
     assert "artifact.txt" in os.listdir(files[0])
+
+
+@pytest.mark.with_auth(True)
+def test_directory_push_pull_selfsigned_auth(
+    tmp_path, registry, credentials, target_dir
+):
+    """
+    Test push and pull for directory using a self-signed cert registry (`tls_verify=False`) and basic auth (`auth_backend="basic"`)
+    """
+    client = oras.client.OrasClient(
+        hostname=registry, tls_verify=False, auth_backend="basic"
+    )
+    res = client.login(
+        hostname=registry,
+        username=credentials.user,
+        password=credentials.password,
+    )
+    assert res["Status"] == "Login Succeeded"
+
+    # Test upload of a directory
+    upload_dir = os.path.join(here, "upload_data")
+    res = client.push(files=[upload_dir], target=target_dir)
+    assert res.status_code == 201
+    files = client.pull(target=target_dir, outdir=tmp_path)
+
+    assert len(files) == 1
+    assert os.path.basename(files[0]) == "upload_data"
+    assert str(tmp_path) in files[0]
+    assert os.path.exists(files[0])
+    assert "artifact.txt" in os.listdir(files[0])

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -25,9 +25,10 @@ def test_login_logout(registry, credentials):
     """
     Login and logout are all we can test with basic auth!
     """
-    client = oras.client.OrasClient(hostname=registry, insecure=True)
+    client = oras.client.OrasClient(hostname=registry, tls_verify=False)
     res = client.login(
         hostname=registry,
+        tls_verify=False,
         username=credentials.user,
         password=credentials.password,
     )


### PR DESCRIPTION
Hi 👋 

This proposed PR fixes what I believe are ~~2~~ edit: *3 problems:
1. atm `do_request` do not maintain `verify=self._tls_verify` for all the `requests`'s calls (it does maintain it only on the first one)
2. The "_One retry if 403 denied (need new token?)_" is actually done _anyway_, and this causes 4xx problem as the third request is always invoked if the second one got invoked, causing 4xx in some scenarios
3. Finally, we need to maintain the headers from the original (first) request in the subsequent ones when augmented with the auth using basic auth

I'm looking forward to your feedback and if I missed anything?

## How was this tested?

locally, I have a pytest as:

```py
@pytest.mark.with_auth(True)
def test_directory_push_pull_selfsigned_auth(tmp_path, registry, credentials, target_dir):
    """
    Test push and pull for directory using a self-signed cert registry and basic auth
    """
    client = oras.client.OrasClient(hostname=registry, tls_verify=False, auth_backend="basic")

    # Test upload of a directory
    upload_dir = os.path.join(here, "upload_data")
    res = client.push(files=[upload_dir], target=target_dir)
    assert res.status_code == 201
    files = client.pull(target=target_dir, outdir=tmp_path)

    assert len(files) == 1
    assert os.path.basename(files[0]) == "upload_data"
    assert str(tmp_path) in files[0]
    assert os.path.exists(files[0])
    assert "artifact.txt" in os.listdir(files[0])
```

I'm using a Zot configured with:
- self signed certs
```
openssl req -newkey rsa:4096 -nodes -sha256 -keyout test/data/server.key -x509 -days 365 -out test/data/server.cert
```
- auth
```
htpasswd -bBn dinosaur oras_pass >> test/data/htpasswd
```

configuration of Zot server:

```json
{
  "distSpecVersion": "1.1.0",
  "storage": {
    "rootDirectory": "/tmp/zot"
  },
  "http": {
    "address": "0.0.0.0",
    "port": "8443",
    "tls": {
      "cert": "test/data/server.cert",
      "key": "test/data/server.key"
    },
    "auth": {
      "htpasswd": {
        "path": "test/data/htpasswd"
      }
    },
    "accessControl": {
      "repositories": {
        "**": {
          "policies": [{
            "users": ["dinosaur"],
            "actions": ["read", "create", "update", "delete"]
          }],
          "defaultPolicy": ["read"],
          "anonymousPolicy": []
        }
      }
    }
  },
  "log": {
    "level": "debug"
  },
  "extensions": {
    "search": {
      "cve": {
        "updateInterval": "2h"
      }
    },
    "ui": {
      "enable": true
    }
  }
}
```

### BEFORE

on main, gives error (`SSLError(SSLCertVerificationError ...`):

```pytest
../../Library/Caches/pypoetry/virtualenvs/testcontainers-ABJcKhkA-py3.12/lib/python3.12/site-packages/urllib3/util/retry.py:515: MaxRetryError

During handling of the above exception, another exception occurred:

tmp_path = PosixPath('/private/var/folders/n0/3c71vqs570b8l21fmnvb5k640000gn/T/pytest-of-mmortari/pytest-89/test_directory_push_pull_selfs0'), registry = 'localhost:8443'
credentials = TestCredentials(with_auth=True, user='dinosaur', password='oras_pass'), target_dir = 'localhost:8443/dinosaur/directory:v1'

    @pytest.mark.with_auth(True)
    def test_directory_push_pull_selfsigned_auth(tmp_path, registry, credentials, target_dir):
        """
        Test push and pull for directory using a self-signed cert registry and basic auth
        """
        client = oras.client.OrasClient(hostname=registry, tls_verify=False, auth_backend="basic")
    
        # Test upload of a directory
        upload_dir = os.path.join(here, "upload_data")
>       res = client.push(files=[upload_dir], target=target_dir)

oras/tests/test_oras.py:150: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
oras/provider.py:762: in push
    response = self.upload_blob(blob, container, layer)
oras/provider.py:275: in upload_blob
    response = self.put_upload(blob, container, layer)
oras/provider.py:518: in put_upload
    r = self.do_request(upload_url, "POST", headers=headers)
oras/decorator.py:60: in __call__
    return self.func(cls, *args, **kwargs)
oras/provider.py:946: in do_request
    response = self.session.request(
../../Library/Caches/pypoetry/virtualenvs/testcontainers-ABJcKhkA-py3.12/lib/python3.12/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
../../Library/Caches/pypoetry/virtualenvs/testcontainers-ABJcKhkA-py3.12/lib/python3.12/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <requests.adapters.HTTPAdapter object at 0x106c187a0>, request = <PreparedRequest [POST]>, stream = False, timeout = Timeout(connect=None, read=None, total=None)
verify = True, cert = None, proxies = OrderedDict()

    def send(
        self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
    ):
        """Sends PreparedRequest object. Returns Response object.
    
        :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
        :param stream: (optional) Whether to stream the request content.
        :param timeout: (optional) How long to wait for the server to send
            data before giving up, as a float, or a :ref:`(connect timeout,
            read timeout) <timeouts>` tuple.
        :type timeout: float or tuple or urllib3 Timeout object
        :param verify: (optional) Either a boolean, in which case it controls whether
            we verify the server's TLS certificate, or a string, in which case it
            must be a path to a CA bundle to use
        :param cert: (optional) Any user-provided SSL certificate to be trusted.
        :param proxies: (optional) The proxies dictionary to apply to the request.
        :rtype: requests.Response
        """
    
        try:
            conn = self.get_connection_with_tls_context(
                request, verify, proxies=proxies, cert=cert
            )
        except LocationValueError as e:
            raise InvalidURL(e, request=request)
    
        self.cert_verify(conn, request.url, verify, cert)
        url = self.request_url(request, proxies)
        self.add_headers(
            request,
            stream=stream,
            timeout=timeout,
            verify=verify,
            cert=cert,
            proxies=proxies,
        )
    
        chunked = not (request.body is None or "Content-Length" in request.headers)
    
        if isinstance(timeout, tuple):
            try:
                connect, read = timeout
                timeout = TimeoutSauce(connect=connect, read=read)
            except ValueError:
                raise ValueError(
                    f"Invalid timeout {timeout}. Pass a (connect, read) timeout tuple, "
                    f"or a single float to set both timeouts to the same value."
                )
        elif isinstance(timeout, TimeoutSauce):
            pass
        else:
            timeout = TimeoutSauce(connect=timeout, read=timeout)
    
        try:
            resp = conn.urlopen(
                method=request.method,
                url=url,
                body=request.body,
                headers=request.headers,
                redirect=False,
                assert_same_host=False,
                preload_content=False,
                decode_content=False,
                retries=self.max_retries,
                timeout=timeout,
                chunked=chunked,
            )
    
        except (ProtocolError, OSError) as err:
            raise ConnectionError(err, request=request)
    
        except MaxRetryError as e:
            if isinstance(e.reason, ConnectTimeoutError):
                # TODO: Remove this in 3.0.0: see #2811
                if not isinstance(e.reason, NewConnectionError):
                    raise ConnectTimeout(e, request=request)
    
            if isinstance(e.reason, ResponseError):
                raise RetryError(e, request=request)
    
            if isinstance(e.reason, _ProxyError):
                raise ProxyError(e, request=request)
    
            if isinstance(e.reason, _SSLError):
                # This branch is for urllib3 v1.22 and later.
>               raise SSLError(e, request=request)
E               requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=8443): Max retries exceeded with url: /v2/dinosaur/directory/blobs/uploads/ (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1000)')))

../../Library/Caches/pypoetry/virtualenvs/testcontainers-ABJcKhkA-py3.12/lib/python3.12/site-packages/requests/adapters.py:620: SSLError
============================================================================= short test summary info ==============================================================================
FAILED oras/tests/test_oras.py::test_directory_push_pull_selfsigned_auth - requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=8443): Max retries exceeded with url: /v2/dinosaur/directory/blobs/uploads/ (Caused by SSLError(SSLCer...
======================================================================== 1 failed, 19 deselected in 10.46s =========================================================================
```

### AFTER

with this PR:

```sh
% env | grep ORAS_
ORAS_HOST=localhost
ORAS_PORT=8443
ORAS_USER=dinosaur
ORAS_PASS=oras_pass
ORAS_AUTH=true
```

```
% pytest -k test_directory_push_pull_selfsigned -s
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.12.3, pytest-7.4.3, pluggy-1.4.0
rootdir: /Users/mmortari/git/oras-py
configfile: pyproject.toml
plugins: asyncio-0.23.5, anyio-4.3.0, cov-4.1.0
asyncio: mode=Mode.STRICT
collected 20 items / 19 deselected / 1 selected                                                                                                                                    

oras/tests/test_oras.py Successfully pushed localhost:8443/dinosaur/directory:v1
.

================================================================================= warnings summary =================================================================================
oras/tests/test_oras.py::test_directory_push_pull_selfsigned_auth
  /opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py:2221: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 1 passed, 19 deselected, 1 warning in 0.28s ====================================================================
```


I didn't find a way to provide integration testing based on the specific use case here:
- self signed server cert
- AND basic auth

but kindly let me know if I missed anything