### PR TITLE
core: make push response the one pertaining to Manifest (not config

### DIFF
--- a/oras/provider.py
+++ b/oras/provider.py
@@ -805,7 +805,10 @@ class Registry:
 
         # Final upload of the manifest
         manifest["config"] = conf
-        self._check_200_response(self.upload_manifest(manifest, container))
+        response = self.upload_manifest(
+            manifest, container
+        )  # make the returned response from this method, the one pertaining to the uploaded Manifest
+        self._check_200_response(response)
         print(f"Successfully pushed {container}")
         return response
 

--- a/oras/tests/test_oras.py
+++ b/oras/tests/test_oras.py
@@ -67,6 +67,28 @@ def test_basic_push_pull(tmp_path, registry, credentials, target):
 
 
 @pytest.mark.with_auth(False)
+def test_basic_push_pul_via_sha_ref(tmp_path, registry, credentials, target):
+    """
+    Basic tests for oras pushing and then pulling with SHA reference
+    """
+    client = oras.client.OrasClient(hostname=registry, insecure=True)
+    artifact = os.path.join(here, "artifact.txt")
+
+    assert os.path.exists(artifact)
+
+    res = client.push(files=[artifact], target=target)
+    assert res.status_code in [200, 201]
+
+    # Test pulling elsewhere
+    using_ref = f"{registry}/dinosaur/artifact@{res.headers['Docker-Content-Digest']}"
+    files = client.pull(target=using_ref, outdir=tmp_path)
+    assert len(files) == 1
+    assert os.path.basename(files[0]) == "artifact.txt"
+    assert str(tmp_path) in files[0]
+    assert os.path.exists(files[0])
+
+
+@pytest.mark.with_auth(False)
 def test_get_delete_tags(tmp_path, registry, credentials, target):
     """
     Test creationg, getting, and deleting tags.


### PR DESCRIPTION
Hi 👋 

I think it would be more helpful for Oras Registry push to return the response pertaining to the (global) Manifest of the push-action --rather then the response only of the config layer, as it's today.

1. step 1/2 with 9702a840ffef4d6712926c8c1cfff26373bddbcc shows test case (would fail on main with "Manifest not found" by means of the SHA)
2. step 2/2 with f6db11a40979252bb4ec26b36c5c0d2ae84d2e29 make the necessary implementation change (trivial change actually)

What do you think?
Hope this is helpful 🙏 