### PR TITLE
core: improve anon/auth token logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ env
 __pycache__
 .python-version
 .venv
+.vscode
+build
+dist

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -44,7 +44,7 @@ class TokenAuth(AuthBackend):
             self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
     def authenticate_request(
-        self, original: requests.Response, headers: dict, refresh=False, skipAnonToken=False
+        self, original: requests.Response, headers: dict, refresh=False
     ):
         """
         Authenticate Request
@@ -72,20 +72,17 @@ class TokenAuth(AuthBackend):
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
         # First try to request an anonymous token
-        if not skipAnonToken:
-            logger.debug("No Authorization, requesting anonymous token")
-            anon_token = self.request_anonymous_token(h)
-            if anon_token:
-                logger.debug("Successfully obtained anonymous token!")
-                self.token = anon_token
-                headers["Authorization"] = "Bearer %s" % self.token
-                return headers, True
+        logger.debug("No Authorization, requesting anonymous token")
+        anon_token = self.request_anonymous_token(h)
+        if anon_token:
+            logger.debug("Successfully obtained anonymous token!")
+            self.token = anon_token
+            headers["Authorization"] = "Bearer %s" % self.token
+            return headers, True
 
         # Next try for logged in token
-        logger.debug("requesting auth token")
         token = self.request_token(h)
         if token:
-            logger.debug("Successfully obtained auth token!")
             self.token = token
             headers["Authorization"] = "Bearer %s" % self.token
             return headers, True

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -44,7 +44,11 @@ class TokenAuth(AuthBackend):
             self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
     def authenticate_request(
-        self, original: requests.Response, headers: dict, refresh=False, skipAnonToken=False
+        self,
+        original: requests.Response,
+        headers: dict,
+        refresh=False,
+        skipAnonToken=False,
     ):
         """
         Authenticate Request
@@ -102,7 +106,7 @@ class TokenAuth(AuthBackend):
         """
         params = {}
         headers = {}
-        if self._basic_auth: # we exchange the basic auth for the token
+        if self._basic_auth:  # we exchange the basic auth for the token
             headers["Authorization"] = "Basic %s" % self._basic_auth
 
         # Prepare request to retry

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -73,7 +73,6 @@ class TokenAuth(AuthBackend):
 
         # if no basic auth, try by request an anonymous token
         if not hasattr(self, "_basic_auth"):
-            logger.debug("No Basic Auth found, requesting anonymous token")
             anon_token = self.request_anonymous_token(h)
             if anon_token:
                 logger.debug("Successfully obtained anonymous token!")
@@ -81,8 +80,7 @@ class TokenAuth(AuthBackend):
                 headers["Authorization"] = "Bearer %s" % self.token
                 return headers, True
 
-        # try using auth token
-        logger.debug("requesting Auth Token")
+        # basic auth is available, try using auth token
         token = self.request_token(h)
         if token:
             self.token = token
@@ -97,7 +95,7 @@ class TokenAuth(AuthBackend):
 
     def request_token(self, h: auth_utils.authHeader) -> bool:
         """
-        Request an authenticated token and save for later.s
+        Request an authenticated token and save for later.
         """
         params = {}
         headers = {}
@@ -126,6 +124,7 @@ class TokenAuth(AuthBackend):
         # Set Basic Auth to receive token
         headers["Authorization"] = "Basic %s" % self._basic_auth
 
+        logger.debug(f"Requesting auth token for: {h}")
         authResponse = self.session.get(h.realm, headers=headers, params=params)  # type: ignore
 
         if authResponse.status_code != 200:
@@ -152,7 +151,7 @@ class TokenAuth(AuthBackend):
         if h.scope:
             params["scope"] = h.scope
 
-        logger.debug(f"Final params are {params}")
+        logger.debug(f"Requesting anon token with params: {params}")
         response = self.session.request("GET", h.realm, params=params)
         if response.status_code != 200:
             logger.debug(f"Response for anon token failed: {response.text}")

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -44,7 +44,7 @@ class TokenAuth(AuthBackend):
             self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
     def authenticate_request(
-        self, original: requests.Response, headers: dict, refresh=False
+        self, original: requests.Response, headers: dict, refresh=False, skipAnonToken=False
     ):
         """
         Authenticate Request
@@ -72,17 +72,20 @@ class TokenAuth(AuthBackend):
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
         # First try to request an anonymous token
-        logger.debug("No Authorization, requesting anonymous token")
-        anon_token = self.request_anonymous_token(h)
-        if anon_token:
-            logger.debug("Successfully obtained anonymous token!")
-            self.token = anon_token
-            headers["Authorization"] = "Bearer %s" % self.token
-            return headers, True
+        if not skipAnonToken:
+            logger.debug("No Authorization, requesting anonymous token")
+            anon_token = self.request_anonymous_token(h)
+            if anon_token:
+                logger.debug("Successfully obtained anonymous token!")
+                self.token = anon_token
+                headers["Authorization"] = "Bearer %s" % self.token
+                return headers, True
 
         # Next try for logged in token
+        logger.debug("requesting auth token")
         token = self.request_token(h)
         if token:
+            logger.debug("Successfully obtained auth token!")
             self.token = token
             headers["Authorization"] = "Bearer %s" % self.token
             return headers, True

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -44,11 +44,7 @@ class TokenAuth(AuthBackend):
             self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
     def authenticate_request(
-        self,
-        original: requests.Response,
-        headers: dict,
-        refresh=False,
-        skipAnonToken=False,
+        self, original: requests.Response, headers: dict, refresh=False, skipAnonToken=False
     ):
         """
         Authenticate Request
@@ -106,7 +102,7 @@ class TokenAuth(AuthBackend):
         """
         params = {}
         headers = {}
-        if self._basic_auth:  # we exchange the basic auth for the token
+        if self._basic_auth: # we exchange the basic auth for the token
             headers["Authorization"] = "Basic %s" % self._basic_auth
 
         # Prepare request to retry

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -72,7 +72,7 @@ class TokenAuth(AuthBackend):
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
         # if no basic auth, try by request an anonymous token
-        if not hasattr(self, '_basic_auth'):
+        if not hasattr(self, "_basic_auth"):
             logger.debug("No Basic Auth found, requesting anonymous token")
             anon_token = self.request_anonymous_token(h)
             if anon_token:

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -71,16 +71,18 @@ class TokenAuth(AuthBackend):
 
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
-        # First try to request an anonymous token
-        logger.debug("No Authorization, requesting anonymous token")
-        anon_token = self.request_anonymous_token(h)
-        if anon_token:
-            logger.debug("Successfully obtained anonymous token!")
-            self.token = anon_token
-            headers["Authorization"] = "Bearer %s" % self.token
-            return headers, True
+        # if no basic auth, try by request an anonymous token
+        if not hasattr(self, '_basic_auth'):
+            logger.debug("No Basic Auth found, requesting anonymous token")
+            anon_token = self.request_anonymous_token(h)
+            if anon_token:
+                logger.debug("Successfully obtained anonymous token!")
+                self.token = anon_token
+                headers["Authorization"] = "Bearer %s" % self.token
+                return headers, True
 
-        # Next try for logged in token
+        # try using auth token
+        logger.debug("requesting Auth Token")
         token = self.request_token(h)
         if token:
             self.token = token

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -99,6 +99,8 @@ class TokenAuth(AuthBackend):
         """
         params = {}
         headers = {}
+        if self._basic_auth: # we exchange the basic auth for the token
+            headers["Authorization"] = "Basic %s" % self._basic_auth
 
         # Prepare request to retry
         if h.service:

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -48,7 +48,7 @@ class TokenAuth(AuthBackend):
         original: requests.Response,
         headers: dict,
         refresh=False,
-        skipAnonToken=False,
+        skip_anon_token=False,
     ):
         """
         Authenticate Request
@@ -76,7 +76,7 @@ class TokenAuth(AuthBackend):
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
         # First try to request an anonymous token
-        if not skipAnonToken:
+        if not skip_anon_token:
             logger.debug("No Authorization, requesting anonymous token")
             anon_token = self.request_anonymous_token(h)
             if anon_token:

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -48,7 +48,7 @@ class TokenAuth(AuthBackend):
         original: requests.Response,
         headers: dict,
         refresh=False,
-        skip_anon_token=False,
+        skipAnonToken=False,
     ):
         """
         Authenticate Request
@@ -76,7 +76,7 @@ class TokenAuth(AuthBackend):
         h = auth_utils.parse_auth_header(authHeaderRaw)
 
         # First try to request an anonymous token
-        if not skip_anon_token:
+        if not skipAnonToken:
             logger.debug("No Authorization, requesting anonymous token")
             anon_token = self.request_anonymous_token(h)
             if anon_token:

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -99,8 +99,6 @@ class TokenAuth(AuthBackend):
         """
         params = {}
         headers = {}
-        if self._basic_auth: # we exchange the basic auth for the token
-            headers["Authorization"] = "Basic %s" % self._basic_auth
 
         # Prepare request to retry
         if h.service:

--- a/oras/auth/utils.py
+++ b/oras/auth/utils.py
@@ -65,6 +65,9 @@ class authHeader:
             if key in ["realm", "service", "scope"]:
                 setattr(self, key, lookup[key])
 
+    def __repr__(self):
+        return f"authHeader(lookup={{'service': {repr(self.service)}, 'realm': {repr(self.realm)}, 'scope': {repr(self.scope)}}})"
+
 
 def parse_auth_header(authHeaderRaw: str) -> authHeader:
     """

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -958,7 +958,7 @@ class Registry:
         :type stream: bool
         """
         # Make the request and return to calling function, but attempt to use auth token if previously obtained
-        if isinstance(self.auth, oras.auth.TokenAuth):
+        if headers is not None and isinstance(self.auth, oras.auth.TokenAuth):
             headers.update(self.auth.get_auth_header())
         response = self.session.request(
             method,

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -1002,19 +1002,5 @@ class Registry:
                 stream=stream,
                 verify=self._tls_verify,
             )
-        # ...or attempt exchange anon token for auth token if 401
-        if response.status_code == 401:
-            headers, changed = self.auth.authenticate_request(
-                response, headers, refresh=True, skipAnonToken=True
-            )
-            response = self.session.request(
-                method,
-                url,
-                data=data,
-                json=json,
-                headers=headers,
-                stream=stream,
-                verify=self._tls_verify,
-            )
 
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -1002,5 +1002,19 @@ class Registry:
                 stream=stream,
                 verify=self._tls_verify,
             )
+        # ...or attempt exchange anon token for auth token if 401
+        if response.status_code == 401:
+            headers, changed = self.auth.authenticate_request(
+                response, headers, refresh=True, skipAnonToken=True
+            )
+            response = self.session.request(
+                method,
+                url,
+                data=data,
+                json=json,
+                headers=headers,
+                stream=stream,
+                verify=self._tls_verify,
+            )
 
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -957,7 +957,9 @@ class Registry:
         :param stream: stream the responses
         :type stream: bool
         """
-        # Make the request and return to calling function, unless requires auth
+        # Make the request and return to calling function, but attempt to use auth token if previously obtained
+        if isinstance(self.auth, oras.auth.TokenAuth):
+            headers.update(self.auth.get_auth_header())
         response = self.session.request(
             method,
             url,


### PR DESCRIPTION
while testing for #147 with ghcr.io and quay.io (so I could test the Token auth backend), I noticed the following and I believe these modification improve on the token backend logic.

I might have missed on something however 😅 , so kindly be patience and let me know if I'm not considering any gap!

Example with ghcr.io: https://github.com/users/tarilabs/packages/container/package/demo20240629-oras147
Example with quay.io: https://quay.io/repository/mmortari/demo20240629-oras147?tab=tags

To make the review hopefully easier, I've left the changes in separate commits, with richer description.

wdyt?

(note: c243eb2 introduced later as in #147 notebooks I was only testing auth backends for push and pull)