### PR TITLE
Fix typo in simple/login.py example

### DIFF
--- a/examples/simple/login.py
+++ b/examples/simple/login.py
@@ -82,7 +82,7 @@ def main(args):
     5. We first try using the docker-py login.
     6. If it fails we fall back to custom setting of credentials.
     """
-    client = oras.client.OrasClient(insecre=args.insecure)
+    client = oras.client.OrasClient(insecure=args.insecure)
     print(client.version())
 
     # Other ways to handle login:


### PR DESCRIPTION
This pull request fixes a typo in the code for `simple/login.py`