### PR TITLE
Enable chunked uploads

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,28 +1,28 @@
 name: Oras Python Tests
 on:
-  pull_request: []
+  pull_request:
 
 jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Check Spelling
-      uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
-      with:
-        files: ./docs ./README.md
+      - uses: actions/checkout@v4
+      - name: Check Spelling
+        uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
+        with:
+          files: ./docs ./README.md
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - name: Lint Oras Python
-      run: |
-        python --version
-        python3 -m pip install pre-commit
-        python3 -m pip install black
-        make develop
-        make lint
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Lint Oras Python
+        run: |
+          python --version
+          python3 -m pip install pre-commit
+          python3 -m pip install black
+          make develop
+          make lint
 
   test-oras-py:
     runs-on: ubuntu-latest
@@ -30,18 +30,53 @@ jobs:
       registry:
         image: ghcr.io/oras-project/registry:latest
         ports:
-        - 5000:5000
+          - 5000:5000
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - name: Test Oras Python
-      env:
-        registry_host: localhost
-        registry_port: ${{ job.services.registry.ports[5000] }}
-        REGISTRY_STORAGE_DELETE_ENABLED: "true"
-      run: |
-        make install
-        make test
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Make space for large files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y google-chrome-stable || true
+          sudo apt purge openjdk-* || echo "OpenJDK is not installed"
+          sudo apt remove --autoremove openjdk-*  || echo "OpenJDK is not installed"
+          sudo apt purge oracle-java* || echo "Oracle Java is not installed"
+          sudo apt remove --autoremove adoptopenjdk-* || echo "Adopt open JDK is not installed"
+          sudo apt-get remove -y ant || echo "ant is not installed"
+          sudo rm -rf /opt/hostedtoolcache/Java_Adopt_jdk || true
+          sudo apt-get remove -y podman || echo "Podman is not installed"
+          sudo apt-get remove -y buildah || echo "Buidah is not installed"
+          sudo apt-get remove -y esl-erlang || echo "erlang is not installed"
+          sudo rm -rf /opt/google
+          sudo rm -rf /usr/share/az* /opt/az || true
+          sudo rm -rf /opt/microsoft
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo apt-get remove -y swift || echo "swift is not installed"
+          sudo apt-get remove -y swig || echo "swig is not installed"
+          sudo apt-get remove -y texinfo || echo "texinfo is not installed"
+          sudo apt-get remove -y texlive || echo "texlive is not installed"
+          sudo apt-get remove -y r-base-core r-base || echo "R is not installed"
+          sudo rm -rf /opt/R
+          sudo rm -rf /usr/share/R
+          sudo rm -rf /opt/*.zip
+          sudo rm -rf /opt/*.tar.gz
+          sudo rm -rf /usr/share/*.zip
+          sudo rm -rf /usr/share/*.tar.gz
+          sudo rm -rf /opt/hhvm
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo apt-get autoremove
+      - name: Test Oras Python
+        env:
+          registry_host: localhost
+          registry_port: ${{ job.services.registry.ports[5000] }}
+          REGISTRY_STORAGE_DELETE_ENABLED: "true"
+        run: |
+          make install
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ oras.egg-info/
 env
 __pycache__
 .python-version
+.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - re-enable chunked upload (0.2.1)
  - refactor of auth to be provided by backend modules (0.2.0)
    - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers
  - Allow generating a Subject from a pre-existing Manifest (0.1.30)

--- a/oras/defaults.py
+++ b/oras/defaults.py
@@ -38,6 +38,9 @@ oci_image_index_file = "index.json"
 # DefaultBlocksize default size of each slice of bytes read in each write through in gunzipand untar.
 default_blocksize = 32768
 
+# DefaultChunkSize default size of each chunk when uploading chunked blobs.
+default_chunksize = 16777216
+
 # what you get for a blank digest, so we don't need to save and recalculate
 blank_hash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/oras/defaults.py
+++ b/oras/defaults.py
@@ -39,7 +39,7 @@ oci_image_index_file = "index.json"
 default_blocksize = 32768
 
 # DefaultChunkSize default size of each chunk when uploading chunked blobs.
-default_chunksize = 16777216
+default_chunksize = 16777216  # 16MB
 
 # what you get for a blank digest, so we don't need to save and recalculate
 blank_hash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,7 @@ import oras.oci
 import oras.provider
 import oras.utils
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = Path(__file__).resolve().parent
 
 
 @pytest.mark.with_auth(False)
@@ -60,6 +61,60 @@ def test_annotated_registry_push(tmp_path, registry, credentials, target):
         res = client.push(
             files=[artifact], target=target, annotation_file=annotation_file
         )
+
+
+@pytest.mark.with_auth(False)
+def test_chunked_push(tmp_path, registry, credentials, target):
+    """
+    Basic tests for oras chunked push
+    """
+    # Direct access to registry functions
+    client = oras.client.OrasClient(hostname=registry, insecure=True)
+    artifact = os.path.join(here, "artifact.txt")
+
+    assert os.path.exists(artifact)
+
+    res = client.push(files=[artifact], target=target, do_chunked=True)
+    assert res.status_code in [200, 201, 202]
+
+    files = client.pull(target, outdir=tmp_path)
+    assert str(tmp_path / "artifact.txt") in files
+    assert oras.utils.get_file_hash(artifact) == oras.utils.get_file_hash(files[0])
+
+    # large file upload
+    base_size = oras.defaults.default_chunksize * 4
+    tmp_chunked = here / "chunked"
+    try:
+        subprocess.run(
+            [
+                "dd",
+                "if=/dev/null",
+                f"of={tmp_chunked}",
+                "bs=1",
+                "count=0",
+                f"seek={base_size}",
+            ],
+        )
+
+        res = client.push(
+            files=[tmp_chunked],
+            target=target,
+            do_chunked=True,
+        )
+        assert res.status_code in [200, 201, 202]
+
+        files = client.pull(target, outdir=tmp_path / "download")
+        download = str(tmp_path / "download/chunked")
+        assert download in files
+        assert oras.utils.get_file_hash(str(tmp_chunked)) == oras.utils.get_file_hash(
+            download
+        )
+    finally:
+        tmp_chunked.unlink()
+
+    # File that doesn't exist
+    with pytest.raises(FileNotFoundError):
+        res = client.push(files=[tmp_path / "none"], target=target)
 
 
 def test_parse_manifest(registry):

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -82,7 +82,7 @@ def test_chunked_push(tmp_path, registry, credentials, target):
     assert oras.utils.get_file_hash(artifact) == oras.utils.get_file_hash(files[0])
 
     # large file upload
-    base_size = oras.defaults.default_chunksize * 4
+    base_size = oras.defaults.default_chunksize * 1024  # 16GB
     tmp_chunked = here / "chunked"
     try:
         subprocess.run(

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd $DIR/../
 
 # Ensure envars are defined - expected registry port and host
-export ORAS_PORT=5000
+export ORAS_PORT=${ORAS_PORT:-5000}
 export ORAS_HOST=localhost
 export ORAS_REGISTRY=${ORAS_HOST}:${ORAS_PORT}
 export ORAS_USER=myuser


### PR DESCRIPTION
TL;DR: Rebases #137. Also fixes out-of-date `_state_` parameter on `session_url`, which caused a 404 when resuming/completing uploads.

We wanted to use oras for larger uploads (say, ML model files) at containers/omlmd, but I wasn't able to make them work with standard uploads. I noticed #137, rebased it, addressed some of your comments (not sure how to address all of them, though). But I still couldn't make it work with https://hub.docker.com/_/registry. So I started debbuging to find out there's a `_state_` parameter being passed around, and I assume it must be updated on the https://distribution.github.io/distribution/spec/api/#completed-upload PUT request to reflect the last state reported by the server. I tested this with 20GB-ish files.

I wonder if this could help with bringing back chunked file support by default, although I'm not really sure in which aspect that kind of support is "flaky" or (as I experienced) poorly documented.