### PR TITLE
Token Auth Backend: Token request function didn`t set Authorization Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
- - add missing basic auth data for request token function in token auth backend
+ - add missing basic auth data for request token function in token auth backend (0.2.2)
  - re-enable chunked upload (0.2.1)
  - refactor of auth to be provided by backend modules (0.2.0)
    - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
- - add missing basic auth data for request token function in token auth backend 
+ - add missing basic auth data for request token function in token auth backend
  - re-enable chunked upload (0.2.1)
  - refactor of auth to be provided by backend modules (0.2.0)
    - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - add missing basic auth data for request token function in token auth backend 
  - re-enable chunked upload (0.2.1)
  - refactor of auth to be provided by backend modules (0.2.0)
    - bugfix maintain requests's verify valorization for all invocations, augment basic auth header to existing headers

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -65,7 +65,6 @@ class TokenAuth(AuthBackend):
             return headers, False
 
         # If we have a token, set auth header (base64 encoded user/pass)
-        # Else if
         if self.token:
             headers["Authorization"] = "Bearer %s" % self.token
             return headers, True
@@ -160,7 +159,6 @@ class TokenAuth(AuthBackend):
         # From https://docs.docker.com/registry/spec/auth/token/ section
         # We can get token OR access_token OR both (when both they are identical)
         data = response.json()
-        print("data: %s" % data)
         token = data.get("token") or data.get("access_token")
 
         # Update the headers but not self.token (expects Basic)

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -34,14 +34,14 @@ class TokenAuth(AuthBackend):
     def get_auth_header(self):
         return {"Authorization": "Bearer %s" % self.token}
 
-    def reset_basic_auth(self) -> str:
+    def reset_basic_auth(self):
         """
         Given we have basic auth, reset it.
         """
         if "Authorization" in self.headers:
             del self.headers["Authorization"]
         if self._basic_auth:
-            return "Basic %s" % self._basic_auth
+            self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
     def authenticate_request(
         self, original: requests.Response, headers: dict, refresh=False

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
In the Token Auth Backend the functin request_token were missing the Authorization Header which failed in not receiving a Bearer Token.