### PR TITLE
Replace logger.exit(...) from the internals

### DIFF
--- a/oras/auth/__init__.py
+++ b/oras/auth/__init__.py
@@ -1,7 +1,5 @@
 import requests
 
-from oras.logger import logger
-
 from .basic import BasicAuth
 from .token import TokenAuth
 
@@ -11,7 +9,7 @@ auth_backends = {"token": TokenAuth, "basic": BasicAuth}
 def get_auth_backend(name="token", session=None, **kwargs):
     backend = auth_backends.get(name)
     if not backend:
-        logger.exit(f"Authentication backend {backend} is not known.")
+        raise ValueError(f"Authentication backend {backend} is not known.")
     backend = backend(**kwargs)
     backend.session = session or requests.Session()
     return backend

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -975,7 +975,7 @@ class Registry:
         # Otherwise, authenticate the request and retry
         headers, changed = self.auth.authenticate_request(response, headers)
         if not changed:
-            logger.exit("Cannot respond to request for authentication.")
+            raise ValueError("Cannot respond to request for authentication.")
         response = self.session.request(
             method,
             url,


### PR DESCRIPTION
Replace with raise ValueError instead so that the caller has the option to handle the problem as they desire.

Fixes: #154