### PR TITLE
Add a dedicated Exemption for auth handlers

### DIFF
--- a/oras/auth/__init__.py
+++ b/oras/auth/__init__.py
@@ -6,6 +6,12 @@ from .token import TokenAuth
 auth_backends = {"token": TokenAuth, "basic": BasicAuth}
 
 
+class AuthenticationException(Exception):
+    """
+    An exception to traise with Authentication errors are fatal
+    """
+
+
 def get_auth_backend(name="token", session=None, **kwargs):
     backend = auth_backends.get(name)
     if not backend:

--- a/oras/auth/__init__.py
+++ b/oras/auth/__init__.py
@@ -8,8 +8,10 @@ auth_backends = {"token": TokenAuth, "basic": BasicAuth}
 
 class AuthenticationException(Exception):
     """
-    An exception to traise with Authentication errors are fatal
+    An exception to raise when Authentication errors are fatal
     """
+
+    pass
 
 
 def get_auth_backend(name="token", session=None, **kwargs):

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -5,6 +5,7 @@ __license__ = "Apache-2.0"
 import time
 from functools import partial, update_wrapper
 
+import oras.auth
 from oras.logger import logger
 
 
@@ -52,6 +53,8 @@ class classretry(Decorator):
         while attempt < attempts:
             try:
                 return self.func(cls, *args, **kwargs)
+            except oras.auth.AuthenticationException as e:
+                raise e
             except Exception as e:
                 sleep = timeout + 3**attempt
                 logger.info(f"Retrying in {sleep} seconds - error: {e}")
@@ -71,6 +74,8 @@ def retry(attempts, timeout=2):
             while attempt < attempts:
                 try:
                     return func(*args, **kwargs)
+                except oras.auth.AuthenticationException as e:
+                    raise e
                 except Exception as e:
                     sleep = timeout + 3**attempt
                     logger.info(f"Retrying in {sleep} seconds - error: {e}")


### PR DESCRIPTION
In 4d248a8 we removed the sys.exit(...) but that now allows for auth failures to be retried by the decorators. Adding a dedicated Exemption so we don't have to retry on fatal auth-failures