### PR TITLE
Allow for filepaths to include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - allow for filepaths to include `:` (0.2.22)
  - release request (0.2.21)
  - add missing basic auth data for request token function in token auth backend (0.2.2)
  - re-enable chunked upload (0.2.1)

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -189,12 +189,6 @@ def test_parse_manifest(registry):
     assert ref == "path/to/config"
     assert content_type == "application/vnd.oci.image.config.v1+json"
 
-    testref = "path/to/config:application/vnd.oci.image.config.v1+json:extra"
-    remote = oras.provider.Registry(hostname=registry, insecure=True)
-    ref, content_type = remote._parse_manifest_ref(testref)
-    assert ref == "path/to/config"
-    assert content_type == "application/vnd.oci.image.config.v1+json:extra"
-
     testref = "/dev/null:application/vnd.oci.image.manifest.v1+json"
     ref, content_type = remote._parse_manifest_ref(testref)
     assert ref == "/dev/null"

--- a/oras/utils/fileio.py
+++ b/oras/utils/fileio.py
@@ -346,7 +346,8 @@ def split_path_and_content(ref: str) -> PathAndOptionalContent:
     : return: A Tuple of the path in the reference, and the content-type if one found,
               otherwise None.
     """
-    if ":" not in ref:
+
+    if os.path.exists(ref) or ":" not in ref:
         return PathAndOptionalContent(ref, None)
 
     if pathlib.Path(ref).drive:
@@ -370,5 +371,5 @@ def split_path_and_content(ref: str) -> PathAndOptionalContent:
             )
         return PathAndOptionalContent(ref, None)
     else:
-        path_content_list = ref.split(":", 1)
+        path_content_list = ref.rsplit(":", 1)
         return PathAndOptionalContent(path_content_list[0], path_content_list[1])

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
When playing with omlmd I tried to push a file which contained a ":" and oras choked on it. I belive that you should check if the file exists and only split off the last : looking for options, not the first colon.