### PR TITLE
Retry on 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - retry on 500 (0.2.25)
  - align provider config_path type annotations (0.2.24)
  - add missing prefix property to auth backend (0.2.23)
  - allow for filepaths to include `:` (0.2.22)

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -3,72 +3,36 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import time
-from functools import partial, update_wrapper
+from functools import wraps
 
 import oras.auth
 from oras.logger import logger
 
 
-class Decorator:
-    """
-    Shared parent decorator class
-    """
-
-    def __init__(self, func):
-        update_wrapper(self, func)
-        self.func = func
-
-    def __get__(self, obj, objtype):
-        return partial(self.__call__, obj)
-
-
-class ensure_container(Decorator):
+def ensure_container(func):
     """
     Ensure the first argument is a container, and not a string.
     """
 
-    def __call__(self, cls, *args, **kwargs):
+    @wraps(func)
+    def wrapper(cls, *args, **kwargs):
         if "container" in kwargs:
             kwargs["container"] = cls.get_container(kwargs["container"])
         elif args:
             container = cls.get_container(args[0])
             args = (container, *args[1:])
-        return self.func(cls, *args, **kwargs)
+        return func(cls, *args, **kwargs)
+
+    return wrapper
 
 
-class classretry(Decorator):
-    """
-    Retry a function that is part of a class
-    """
-
-    def __init__(self, func, attempts=5, timeout=2):
-        super().__init__(func)
-        self.attempts = attempts
-        self.timeout = timeout
-
-    def __call__(self, cls, *args, **kwargs):
-        attempt = 0
-        attempts = self.attempts
-        timeout = self.timeout
-        while attempt < attempts:
-            try:
-                return self.func(cls, *args, **kwargs)
-            except oras.auth.AuthenticationException as e:
-                raise e
-            except Exception as e:
-                sleep = timeout + 3**attempt
-                logger.info(f"Retrying in {sleep} seconds - error: {e}")
-                time.sleep(sleep)
-                attempt += 1
-        return self.func(cls, *args, **kwargs)
-
-
-def retry(attempts, timeout=2):
+def retry(attempts=5, timeout=2):
     """
     A simple retry decorator
     """
 
     def decorator(func):
+        @wraps(func)
         def inner(*args, **kwargs):
             attempt = 0
             while attempt < attempts:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -840,6 +840,9 @@ class Registry:
         response = self.upload_manifest(
             manifest, container
         )  # make the returned response from this method, the one pertaining to the uploaded Manifest
+        if response.status_code == 500:
+            # retry once
+            response = self.upload_manifest(manifest, container)
         self._check_200_response(response)
         print(f"Successfully pushed {container}")
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -840,9 +840,6 @@ class Registry:
         response = self.upload_manifest(
             manifest, container
         )  # make the returned response from this method, the one pertaining to the uploaded Manifest
-        if response.status_code == 500:
-            # retry once
-            response = self.upload_manifest(manifest, container)
         self._check_200_response(response)
         print(f"Successfully pushed {container}")
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -938,7 +938,7 @@ class Registry:
         jsonschema.validate(manifest, schema=oras.schemas.manifest)
         return manifest
 
-    @decorator.classretry
+    @decorator.retry()
     def do_request(
         self,
         url: str,

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.24"
+__version__ = "0.2.25"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This is the standard policy in the upstream [oras-project/oras-go](https://github.com/oras-project/oras-go/blob/bf570bcc78b3aa1bad84401e3390cc79a03e426e/registry/remote/retry/policy.go#L56). It actually fixes an issue when uploading manifests to Quay.io, as can be observed in this HTTP traffic capture from WireShark:

![image](https://github.com/user-attachments/assets/fe2fd357-b3d1-4e6b-a3c7-6bbc07bb1c44)

Tested with a local instance and also with Quay.io successfully following https://github.com/isinyaaa/quay-demo.git
Remote upload https://quay.io/repository/idoamara/testrepo verified with `oras cp quay.io/idoamara/testrepo:v1 --to-oci-layout testrepo-mirror`