### PR TITLE
check for blob existence in registry before uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - check for blob existence before uploading (0.2.26)
  - retry on 500 (0.2.25)
  - align provider config_path type annotations (0.2.24)
  - add missing prefix property to auth backend (0.2.23)


### PR DESCRIPTION
I noticed oras-py uploads blobs even when they already exist in the registry. 
As this is an unwanted behaviour I added a check with a HEAD request to see if a blob (layer) already exists for a given container. 

