### PR TITLE
fix: join next link instead of append for pagination in get_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
  - check for blob existence before uploading (0.2.26)
+    - fix get_tags for ECR when limit is None, closes issue [173](https://github.com/oras-project/oras-py/issues/173)
  - retry on 500 (0.2.25)
  - align provider config_path type annotations (0.2.24)
  - add missing prefix property to auth backend (0.2.23)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -398,7 +398,7 @@ class Registry:
                 break
 
             # use link + base url to continue with next page
-            url = f"{base_url}{link}"
+            url = urllib.parse.urljoin(base_url, link)
 
     @decorator.ensure_container
     def get_blob(

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.25"
+__version__ = "0.2.26"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Resolves https://github.com/oras-project/oras-py/issues/173

Some simple testing (see original issue for reproduction):

```
>>> tags = client.get_tags('my/image')
>>> len(tags)
3232
>>> tags = client.get_tags('my/image', N=100)
>>> len(tags)
100
>>> tags = client.get_tags('my/image', N=1)
>>> len(tags)
1
>>> tags = client.get_tags('my/other_image')
>>> len(tags)
5
>>> tags = client.get_tags('my/other_image', N=10)
>>> len(tags)
5
>>> tags = client.get_tags('my/other_image', N=1)
>>> len(tags)
1
```

Note that an error will still occur when passing `N > 1000` but I'm not trying to add that guardrail here.