### PR TITLE
fix: do not set empty token so anon works for public ecr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
  - check for blob existence before uploading (0.2.26)
-    - fix get_tags for ECR when limit is None, closes issue [173](https://github.com/oras-project/oras-py/issues/173)
+   - fix get_tags for ECR when limit is None, closes issue [173](https://github.com/oras-project/oras-py/issues/173)
+   - fix empty token for anon tokens to work, closes issue [167](https://github.com/oras-project/oras-py/issues/167)
  - retry on 500 (0.2.25)
  - align provider config_path type annotations (0.2.24)
  - add missing prefix property to auth backend (0.2.23)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -983,7 +983,11 @@ class Registry:
         :type stream: bool
         """
         # Make the request and return to calling function, but attempt to use auth token if previously obtained
-        if headers is not None and isinstance(self.auth, oras.auth.TokenAuth):
+        if (
+            headers is not None
+            and isinstance(self.auth, oras.auth.TokenAuth)
+            and self.auth.token is not None
+        ):
             headers.update(self.auth.get_auth_header())
         response = self.session.request(
             method,


### PR DESCRIPTION
Fixes https://github.com/oras-project/oras-py/issues/167

The TokenAuth object has a None value for token until a login is executed. AWS ECR returns a `400 Bad Request` when presented with `Authorization: Bearer None` while Docker Hub returns a `401 Unauthorized` with proper `www-authenticate` header.

This patch simply skips adding `Authorization: Bearer None` which AWS ECR seems to expect. Docker Hub seems to handle the lack of Authorization header the same as if it got `Bearer None`.

My testing of this patch follows.

```
>>> from oras.logger import setup_logger, logger
>>> setup_logger(quiet=False, debug=True)
>>> from oras.client import OrasClient
>>> client = OrasClient('public.ecr.aws')
>>> client.get_tags('/aws-controllers-k8s/acm-chart')
Requesting anon token with params: {'service': 'public.ecr.aws', 'scope': 'aws'}
Successfully obtained anonymous token!

client = OrasClient('registry.hub.docker.com')
client.get_tags('openresty/openresty', N=10)
['0.0.13', '0.0.19', '0.0.20', 'v0.0.6', '0.0.4', '0.0.5', '0.0.11', '0.0.7', 'v0.0.4', '0.0.17', '0.0.16', 'v0.0.3', '0.0.6', 'v0.0.5', 'v0.0.1', '0.0.10', 'v0.0.2', '0.0.2', '0.0.8', '0.0.18', '0.0.3', '0.0.1', '0.0.15', '1.0.0', '0.0.12', '0.0.9', '0.0.14']
>>>
>>> client = OrasClient('registry.hub.docker.com')
>>> client.get_tags('openresty/openresty', N=10)
Requesting anon token with params: {'service': 'registry.docker.io', 'scope': 'repository:openresty/openresty:pull'}
Successfully obtained anonymous token!
['1.11.2.1-alpine', '1.11.2.1-centos', '1.11.2.1-centos-rpm', '1.11.2.1-trusty', '1.11.2.1-xenial', '1.11.2.2-alpine', '1.11.2.2-alpine-fat', '1.11.2.2-centos', '1.11.2.2-centos-rpm', '1.11.2.2-jessie']
>>>
```