### PR TITLE
Fix token authentication doc

### DIFF
--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -628,7 +628,7 @@ here is asking for the default.
 ```python
 import oras.client
 client = oras.client.OrasClient(auth_backend="token")
-client.login(password="myuser", username="myuser", insecure=True)
+client.auth.set_token_auth("my_bearer_token")
 ```
 
 If you wanted to always maintain the basic auth you might do:


### PR DESCRIPTION
As discussed [here](https://github.com/oras-project/oras-py/issues/180#issuecomment-2598381914), it's a proposal of doc update on token auth that worked for me, but I have no clue if it has other impact, as I only use oras-py to list helm charts available versions on OCI repos.