### PR TITLE
Avoid Setting Unspecified Header Fields When Pushing Manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - don't include Content-Length header in upload_manifest (0.2.29)
  - propagate the tls_verify parameter to auth backends (0.2.28)
  - don't add an Authorization header is there is no token (0.2.27), closes issue [182](https://github.com/oras-project/oras-py/issues/182)
  - check for blob existence before uploading (0.2.26)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -704,7 +704,6 @@ class Registry:
         jsonschema.validate(manifest, schema=oras.schemas.manifest)
         headers = {
             "Content-Type": oras.defaults.default_manifest_media_type,
-            "Content-Length": str(len(manifest)),
         }
         return self.do_request(
             f"{self.prefix}://{container.manifest_url()}",  # noqa

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.28"
+__version__ = "0.2.29"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This PR addresses compatibility issues with various OCI registry implementations. Some registries are more strict than others when it comes to certain HTTP headers, which can lead to unexpected errors or behavior.

Aside from the `Content-Length` being calculated incorrectly, the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests) does not require or even mention this header when pushing manifests.

Let me know if I overlooked some detail and thanks for your work ✌️