### PR TITLE
fix: initialize headers variable in do_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - initialize headers variable in do_request (0.2.31)
  - Make reproducible targz without mimetype (0.2.30)
  - don't include Content-Length header in upload_manifest (0.2.29)
  - propagate the tls_verify parameter to auth backends (0.2.28)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -559,9 +559,7 @@ class Registry:
             )
         return response
 
-    def blob_exists(
-        self, layer: oras.oci.Layer, container: oras.container.Container
-    ) -> bool:
+    def blob_exists(self, layer: dict, container: oras.container.Container) -> bool:
         """
         Check if a layer already exists in the registry.
 
@@ -983,12 +981,11 @@ class Registry:
         :param stream: stream the responses
         :type stream: bool
         """
+        if headers is None:
+            headers = {}
+
         # Make the request and return to calling function, but attempt to use auth token if previously obtained
-        if (
-            headers is not None
-            and isinstance(self.auth, oras.auth.TokenAuth)
-            and self.auth.token is not None
-        ):
+        if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
             headers.update(self.auth.get_auth_header())
         response = self.session.request(
             method,

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.30"
+__version__ = "0.2.31"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This *PR* does two things:
1) initializes the variable _headers_ in `do_request`
2) fixes the type annotation of `blob_exists`

### To 1)
The method signature of `do_request` looks like this:
```py
def do_request(
     self,
     url: str,
     method: str = "GET",
     data: Optional[Union[dict, bytes]] = None,
     headers: Optional[dict] = None,
     json: Optional[dict] = None,
     stream: bool = False,
) -> requests.Response:
```
where *headers* is an optional _dict_ with the correct default  _None_ . The problem comes later when *do_request* calls `self.auth.authenicate_request` which has the  signature:

```py
def authenticate_request(
     self, 
     original: requests.Response, 
     headers: dict,
     refresh=False,
):
```
which expects the headers to be a **dict instance** in order to update the _Authorization_ header.

I therefore initialize the headers variable to an empty dict. I encountered this error when executing the `blob_exists` method which does not pass any headers to `do_request`. 

If this is not your desired solution I would also be happy to open an issue detailing the problem as well.

### To 2)
The method signature of `blob_exists` looks like this:

```py
def blob_exists(
    self, 
    layer: oras.oci.Layer, 
    container: oras.container.Container,
) -> bool:
```
the method uses it like this: `layer["digest"]` which means that the type annotation cannot be correct as  oras.oci.Layer does not support `__getitem__` 