### PR TITLE
token.py ensure headers is defined

### DIFF
--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -57,6 +57,7 @@ class TokenAuth(AuthBackend):
         :param original: original response to get the Www-Authenticate header
         :type original: requests.Response
         """
+        headers = headers or {}
         if refresh:
             self.token = None
         authHeaderRaw = original.headers.get("Www-Authenticate")


### PR DESCRIPTION
Hit a bug in a wild where headers is None, and then we try to set "Authorization" and hit an error.