### PR TITLE
Add TLS Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - allow specification of server and client certificates (0.3.0)
  - initialize headers variable in do_request (0.2.31)
  - Make reproducible targz without mimetype (0.2.30)
  - don't include Content-Length header in upload_manifest (0.2.29)

--- a/oras/auth/__init__.py
+++ b/oras/auth/__init__.py
@@ -14,14 +14,11 @@ class AuthenticationException(Exception):
     pass
 
 
-def get_auth_backend(
-    name="token", session=None, insecure=False, tls_verify=True, **kwargs
-):
+def get_auth_backend(name="token", session=None, insecure=False, **kwargs):
     backend = auth_backends.get(name)
     if not backend:
         raise ValueError(f"Authentication backend {backend} is not known.")
     backend = backend(**kwargs)
     backend.session = session or requests.Session()
     backend.prefix = "http" if insecure else "https"
-    backend._tls_verify = tls_verify
     return backend

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -20,7 +20,6 @@ class AuthBackend:
     """
 
     session: requests.Session
-    _tls_verify: bool
 
     def __init__(self, *args, **kwargs):
         self._auths: dict = {}

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -128,7 +128,7 @@ class TokenAuth(AuthBackend):
         headers["Authorization"] = "Basic %s" % self._basic_auth
 
         logger.debug(f"Requesting auth token for: {h}")
-        authResponse = self.session.get(h.realm, headers=headers, params=params, verify=self._tls_verify)  # type: ignore
+        authResponse = self.session.get(h.realm, headers=headers, params=params)  # type: ignore
 
         if authResponse.status_code != 200:
             logger.debug(f"Auth response was not successful: {authResponse.text}")
@@ -155,9 +155,7 @@ class TokenAuth(AuthBackend):
             params["scope"] = h.scope
 
         logger.debug(f"Requesting anon token with params: {params}")
-        response = self.session.request(
-            "GET", h.realm, params=params, verify=self._tls_verify
-        )
+        response = self.session.request("GET", h.realm, params=params)
         if response.status_code != 200:
             logger.debug(f"Response for anon token failed: {response.text}")
             return

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.31"
+__version__ = "0.3.0"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This PR adds tls verification options and solves #185.

---
At the moment only _insecure_ (no tls verification) is supported which I'd like to change since I cannot rely on the hosts CA Bundles which _requests_ uses by [default](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification).

The tls options are also supported by the [oras binary](https://oras.land/docs/commands/oras_blob_push#options).