### PR TITLE
fix: method signature to allow custom CA-Bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - fix 'Provider' method signature to allow custom CA-Bundles (0.2.32)
  - initialize headers variable in do_request (0.2.31)
  - Make reproducible targz without mimetype (0.2.30)
  - don't include Content-Length header in upload_manifest (0.2.29)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -48,7 +48,7 @@ class Registry:
         self,
         hostname: Optional[str] = None,
         insecure: bool = False,
-        tls_verify: bool = True,
+        tls_verify: Union[bool, str] = True,
         auth_backend: str = "token",
     ):
         """
@@ -58,10 +58,12 @@ class Registry:
 
         :param hostname: the hostname of the registry to ping
         :type hostname: str
-        :param registry: if provided, use this custom provider instead of default
-        :type registry: oras.provider.Registry or None
         :param insecure: use http instead of https
         :type insecure: bool
+        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+        :type tls_verify: bool
+        :param auth_backend: name of the auth backend to use
+        :type auth_backend: str
         """
         self.hostname: Optional[str] = hostname
         self.headers: dict = {}

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.31"
+__version__ = "0.2.32"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION

As opposed to #197 I only fixed the comment and kept away from changing anything else..
Setting tls_verify to a string works already but I do not want to set a string to a boolean so to make it 'official' here the PR