### PR TITLE
fix(auth): call 'load_configs()' to load auth infos from '.docker/con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - fix 'get_manifest()' method with adding 'load_configs()' calling (0.2.33)
  - fix 'Provider' method signature to allow custom CA-Bundles (0.2.32)
  - initialize headers variable in do_request (0.2.31)
  - Make reproducible targz without mimetype (0.2.30)

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -124,10 +124,18 @@ class TokenAuth(AuthBackend):
             logger.debug(f"Scope: {h.scope}")
             params["scope"] = h.scope
 
-        # Set Basic Auth to receive token
-        headers["Authorization"] = "Basic %s" % self._basic_auth
+        # Set Basic Auth to receive token, if available
+        if hasattr(self, "_basic_auth") and self._basic_auth:
+            headers["Authorization"] = "Basic %s" % self._basic_auth
+            logger.debug("Using Basic Auth for token request.")
+        else:
+            logger.debug(
+                "No Basic Auth available or configured for token request. Proceeding without Basic Auth header for token endpoint."
+            )
 
-        logger.debug(f"Requesting auth token for: {h}")
+        logger.debug(
+            f"Requesting auth token for: {h} with header keys: {list(headers.keys())}"
+        )
         authResponse = self.session.get(h.realm, headers=headers, params=params, verify=self._tls_verify)  # type: ignore
 
         if authResponse.status_code != 200:

--- a/oras/auth/utils.py
+++ b/oras/auth/utils.py
@@ -34,6 +34,7 @@ def load_configs(configs: Optional[List[str]] = None):
             continue
         cfg = oras.utils.read_json(config)
         auths.update(cfg.get("auths", {}))
+
     return auths
 
 

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -946,12 +946,17 @@ class Registry:
         :param allowed_media_type: one or more allowed media types
         :type allowed_media_type: str
         """
+        # Load authentication configs for the container's registry
+        # This ensures credentials are available for authenticated registries
+        self.auth.load_configs(container)
+
         if not allowed_media_type:
             allowed_media_type = [oras.defaults.default_manifest_media_type]
         headers = {"Accept": ";".join(allowed_media_type)}
 
         get_manifest = f"{self.prefix}://{container.manifest_url()}"  # type: ignore
         response = self.do_request(get_manifest, "GET", headers=headers)
+
         self._check_200_response(response)
         manifest = response.json()
         jsonschema.validate(manifest, schema=oras.schemas.manifest)

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.32"
+__version__ = "0.2.33"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
In provider.py, both 'push()' and 'pull()' call 'load_configs()'. There is no reason 'get_manifest()' won't call it. 

One case is if you call 'docker/login-action' to login the GHCR, it will save the auth infos in '.docker/config.json', without calling 'load_configs()', it can't load the user/password and will throw:

`'TokenAuth' object has no attribute '_basic_auth'`

