### PR TITLE
Add support for Docker credsStore and credHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Add support for Docker credsStore and credHelpers
  - fix 'get_manifest()' method with adding 'load_configs()' calling (0.2.33)
  - fix 'Provider' method signature to allow custom CA-Bundles (0.2.32)
  - initialize headers variable in do_request (0.2.31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
- - Add support for Docker credsStore and credHelpers
+ - Add support for Docker credsStore and credHelpers (0.2.34)
  - fix 'get_manifest()' method with adding 'load_configs()' calling (0.2.33)
  - fix 'Provider' method signature to allow custom CA-Bundles (0.2.32)
  - initialize headers variable in do_request (0.2.31)

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -678,16 +678,8 @@ More verbose output should appear.
 
 > I get unauthorized when trying to login to an Amazon ECR Registry
 
-Note that for [Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html)
-you might need to login per the instructions at the link provided. If you look at your `~/.docker/config.json` and see
-that there is a "credsStore" section that is populated, you might also need to comment this out
-while using oras-py. Oras-py currently doesn't support reading external credential stores, so you will
-need to comment it out, login again, and then try your request. To sanity check that you've done
-this correctly, you should see an "auth" key under a hostname under "auths" in this file with a base64
-encoded string (this is actually your username and password!) An empty dictionary there indicates that you
-are using a helper. Finally, it would be cool if we supported these external stores! If you
-want to contribute this or help think about how to do it, @vsoch would be happy to help.
-
+If you have configured a credsStore or a credHelper in your Docker config, you should remember
+to use the basic auth backend.
 
 
 ## Custom Clients

--- a/oras/auth/utils.py
+++ b/oras/auth/utils.py
@@ -26,16 +26,24 @@ def load_configs(configs: Optional[List[str]] = None):
         configs.append(default_config)
     configs = set(configs)  # type: ignore
 
-    # Load configs until we find our registry hostname
+    # Load configs
     auths = {}
+    creds_store = None
+    cred_helpers = {}
     for config in configs:
         if not os.path.exists(config):
             logger.warning(f"{config} does not exist.")
             continue
         cfg = oras.utils.read_json(config)
         auths.update(cfg.get("auths", {}))
+        creds_store = cfg.get("credsStore")
+        cred_helpers.update(cfg.get("credHelpers", {}))
 
-    return auths
+    return {
+        "auths": auths,
+        "credsStore": creds_store,
+        "credHelpers": cred_helpers,
+    }
 
 
 def get_basic_auth(username: str, password: str):

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
This updates the basic backend to also support using Docker credsStore and Docker credHelpers.

```python
client = oras.client.OrasClient(auth_backend="basic")
client.pull(target="123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:latest")
```

