### PR TITLE
fix: auth via ECR to be an extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - fix 'authentication with ECR' to be an extra as intended (0.2.35)
  - Add support for authentication with ECR registries (0.2.34)
  - Add support for Docker credsStore and credHelpers
  - fix 'get_manifest()' method with adding 'load_configs()' calling (0.2.33)

--- a/oras/auth/ecr.py
+++ b/oras/auth/ecr.py
@@ -4,7 +4,7 @@ __license__ = "Apache-2.0"
 
 import re
 
-import boto3
+# do not `import boto3` as it's the `ecr` extra, see setup.py
 import requests
 
 import oras.auth.utils as auth_utils
@@ -54,6 +54,17 @@ class EcrAuth(TokenAuth):
                 logger.warning(f"realm: {h.realm} did not match expected pattern.")
                 return super().request_token(h)
             region = m.group("region")
+            try: # avoid mandatory requirement on `boto3`
+                import boto3
+            except ImportError as e:
+                msg = """the `boto3` dependency is required to support authentication to this registry.
+                Make sure to install the required extra, e.g.:
+
+                ```sh
+                pip install oras[ecr]
+                ```
+                """
+                raise ImportError(msg) from e
             ecr = boto3.client("ecr", region_name=region)
             auth = ecr.get_authorization_token()["authorizationData"][0]
             token = auth.get("authorizationToken", "")

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -54,6 +54,8 @@ def retry(attempts=5, timeout=2):
                     raise e
                 except requests.exceptions.SSLError:
                     raise
+                except ImportError as e:
+                    raise e
                 except Exception as e:
                     sleep = timeout + 3**attempt
                     logger.info(f"Retrying in {sleep} seconds - error: {e}")

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.34"
+__version__ = "0.2.35"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
as intended in original PR. 

# Details

Hi @vsoch @rasmusfaber , thank you for the recent addition; I've found a small glitch, as now the tutorial when installing `oras` (with no extras) fails on inits due to missing boto3 import (which I understand is meant to be an Extra).

# Before this PR

```py
import oras.provider

# tutorial: https://oras-project.github.io/oras-py/getting_started/user-guide.html
class MyProvider(oras.provider.Registry):
    pass


def main():
    provider = MyProvider()
    print("Hello world")


if __name__ == "__main__":
    main()
``` 

failing with:

```
% python main.py 
Traceback (most recent call last):
  File "/Users/mmortari/git/demo20250609-orasDepBug/main.py", line 1, in <module>
    import oras.provider
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/provider.py", line 18, in <module>
    import oras.auth
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/auth/__init__.py", line 4, in <module>
    from .ecr import EcrAuth
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/auth/ecr.py", line 7, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
```

I see ECR is indeed intended as extra, but the problem per stack trace is that there is an `import boto3` in the chain of inits.

## After this PR

This change would make it work when following the tutorial:

```
% python main.py 
Hello world
```

Further I'm making import error fail-fast, for example using this snippet as reproducer:

```py
import oras.provider

# tutorial: https://oras-project.github.io/oras-py/getting_started/user-guide.html
class MyProvider(oras.provider.Registry):
    pass


def main():
    provider = MyProvider()
    print("Hello world")

    import oras.client
    client = oras.client.OrasClient(auth_backend="ecr")
    client.pull(target="123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest")


if __name__ == "__main__":
    main()
```

making it fail-fast with:

```
% python main.py                          
Hello world
Traceback (most recent call last):
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/auth/ecr.py", line 58, in authenticate_request
    import boto3
ModuleNotFoundError: No module named 'boto3'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/mmortari/git/demo20250609-orasDepBug/main.py", line 18, in <module>
    main()
  File "/Users/mmortari/git/demo20250609-orasDepBug/main.py", line 14, in main
    client.pull(target="123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest")
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/provider.py", line 897, in pull
    manifest = self.get_manifest(container, allowed_media_type)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/decorator.py", line 26, in wrapper
    return func(cls, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/provider.py", line 958, in get_manifest
    response = self.do_request(get_manifest, "GET", headers=headers)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/decorator.py", line 58, in inner
    raise e
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/decorator.py", line 42, in inner
    res = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/provider.py", line 1012, in do_request
    headers, changed = self.auth.authenticate_request(response, headers)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mmortari/git/demo20250609-orasDepBug/venv/lib/python3.12/site-packages/oras/auth/ecr.py", line 67, in authenticate_request
    raise ImportError(msg) from e
ImportError: the `boto3` dependency is required to support authentication to this registry.
                Make sure to install the required extra, e.g.:

                ```sh
                pip install oras[ecr]
                ```
                
```

## Changelog

maintained version bump and changelog accordingly

Hope this helps!