### PR TITLE
Use correct credsStore/credHelpers binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Use the correct credsStore/credHelpers binary (0.2.37)
  - Properly prioritize auth methods (0.2.36)
  - fix 'authentication with ECR' to be an extra as intended (0.2.35)
  - Add support for authentication with ECR registries (0.2.34)

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -64,7 +64,8 @@ class AuthBackend:
     def _logout(self):
         pass
 
-    def _get_auth_from_creds_store(self, binary: str, hostname: str) -> str | None:
+    def _get_auth_from_creds_store(self, suffix: str, hostname: str) -> str | None:
+        binary = f"docker-credential-{suffix}"
         try:
             proc = subprocess.run(
                 [binary, "get"],

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.36"
+__version__ = "0.2.37"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Sorry, one more fix. The actual binary to use for Docker credsStore/credHelpers is defined by prepending `docker-credential-` to the value defined by `docker/config-json`.

Signed-off-by: Rasmus Faber-Espensen <rfaber@gmail.com>
