### PR TITLE
fix Python 3.7+ compatibility by avoiding union syntax and rely on typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - fix Python 3.7+ compatibility by avoiding union syntax and rely on typing (0.2.38)
  - Use the correct credsStore/credHelpers binary (0.2.37)
  - Properly prioritize auth methods (0.2.36)
  - fix 'authentication with ECR' to be an extra as intended (0.2.35)

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -64,7 +64,7 @@ class AuthBackend:
     def _logout(self):
         pass
 
-    def _get_auth_from_creds_store(self, suffix: str, hostname: str) -> str | None:
+    def _get_auth_from_creds_store(self, suffix: str, hostname: str) -> Optional[str]:
         binary = f"docker-credential-{suffix}"
         try:
             proc = subprocess.run(

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.37"
+__version__ = "0.2.38"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
Oras is declared as Python 3.7+ compatible:

https://github.com/oras-project/oras-py/blob/b648fd36cb600537d33597e4c2291575770283bc/setup.py#L105

but #212 introduced newer Python syntax.

Fix propose to rely on `typing`.

cc @rasmusfaber @vsoch 