### PR TITLE
Add auth headers to request when using BasicAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - Add Auth headers to request when using `BasicAuth` (0.2.39)
  - fix Python 3.7+ compatibility by avoiding union syntax and rely on typing (0.2.38)
  - Use the correct credsStore/credHelpers binary (0.2.37)
  - Properly prioritize auth methods (0.2.36)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -992,7 +992,13 @@ class Registry:
             headers = {}
 
         # Make the request and return to calling function, but attempt to use auth token if previously obtained
-        if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
+        if (
+            isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None
+        ) or (
+            isinstance(self.auth, oras.auth.BasicAuth)
+            and hasattr(self.auth, "_basic_auth")
+            and self.auth._basic_auth is not None
+        ):
             headers.update(self.auth.get_auth_header())
         response = self.session.request(
             method,

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.38"
+__version__ = "0.2.39"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
# Problem
I'm currently using `oras-py` as client library for a Zot OCI registry. In my current (rather simple) setup, I'm only using `BasicAuth` with username and password, no `TokenAuth`.
I noticed that when pushing a blob (by calling `registry.upload_blob()`), there is no authentication header, and thus Zot _sometimes_ rejects the push.
I say _sometimes_, because other times Zot seems fine without the auth header, and accepts the push. It's really hard to debug...
When adding the auth header to every request, Zot is happy.

I saw that there's a test for pushing using basic auth [oras/tests/test_oras.py#L168](https://github.com/oras-project/oras-py/blob/main/oras/tests/test_oras.py#L168) which I would expect to fail as well, so I really don't know...

# Proposed Solution
Add the auth headers to the request, just like it's done with `TokenAuth`.

NB: I have no clue if this is the right way, or if I'm misusing `oras-py` and should solve this a completely different way

# Steps to reproduce

my client script essentially looks like this:
```
registry = Registry(hostname=host, tls_verify=tls_verify, auth_backend="basic")
res = registry.login(hostname=HOSTNAME, username=USERNAME, password=PASSWORD, tls_verify=false)
assert res["Status"] == "Login Succeeded"
container = oras.container.Container(f"{ HOSTNAME }/{ ARTIFACT }")

[...]
layer = oras.oci.NewLayer(elem.path, is_dir=False)
layer["annotations"] = {oras.defaults.annotation_title: str(elem.name)}

registry._check_200_response(registry.upload_blob(elem, container, layer))
[...]
````

relevant parts of Zot configuration:
```
  "http": {
    "address": "0.0.0.0",
    "port": "8080",
    "compat": ["docker2s2"],
    "realm": "zotserver",
    "tls": {
      "cert": "/etc/zot/server_san.crt",
      "key": "/etc/zot/server.key"
    },
    "auth": {
      "htpasswd": {
        "path": "/etc/zot/htpasswd"
      },
      "failDelay": 5
    },
    "accessControl": {
      "groups": {
        "admins": {
          "users": ["corin"]
        },
        "readers": {
          "users": ["githubrunner_read",]
        }
      },
      "repositories": {
        "**": {
          "policies": [{
              "groups": ["readers"],
              "actions": ["read"]
            },
            {
              "groups": ["admins"],
              "actions": ["read", "create", "update", "delete"]
            }]
        }
      }
    }
  },
```