### PR TITLE
introduce modelpack for model in OCI format

### DIFF
--- a/oras/defaults.py
+++ b/oras/defaults.py
@@ -48,3 +48,6 @@ blank_hash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b785
 blank_config_hash = (
     "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
 )
+
+# ModelPack annotations, refer to https://github.com/modelpack/model-spec/blob/main/specs-go/v1/annotations.go
+annotation_filepath = "org.cnai.model.filepath"

--- a/oras/utils/__init__.py
+++ b/oras/utils/__init__.py
@@ -1,6 +1,10 @@
 from .fileio import (
     copyfile,
+    extract_by_compression,
+    extract_tar,
+    extract_tar_zstd,
     extract_targz,
+    get_compression_from_media_type,
     get_file_hash,
     get_size,
     get_tmpdir,


### PR DESCRIPTION
### Summary
This PR enhances the ORAS Python client to support multiple compression formats by implementing suffix-based compression detection, replacing hardcoded media type comparison with a flexible approach. So we can use this to support various media types (for example, from https://github.com/modelpack/model-spec/blob/main/specs-go/v1/mediatype.go) instead of the original specific one.

### Key Changes

#### 1. New Compression Functions ([oras/utils/fileio.py](cci:7://file:///Users/lucas/github/oras-py/oras/utils/fileio.py:0:0-0:0))
- [extract_tar()](cci:1://file:///Users/lucas/github/oras-py/oras/utils/fileio.py:105:0-114:73): Handles uncompressed tar archives
- [extract_tar_zstd()](cci:1://file:///Users/lucas/github/oras-py/oras/utils/fileio.py:117:0-138:76): Supports zstd-compressed archives (requires `zstandard` package)
- [get_compression_from_media_type()](cci:1://file:///Users/lucas/github/oras-py/oras/utils/fileio.py:141:0-160:21): Detects compression format from media type suffixes
- [extract_by_compression()](cci:1://file:///Users/lucas/github/oras-py/oras/utils/fileio.py:163:0-186:74): Generic extraction dispatcher

#### 2. Enhanced Provider Logic ([oras/provider.py](cci:7://file:///Users/lucas/github/oras-py/oras/provider.py:0:0-0:0))
- Replaced hardcoded media type check with suffix-based detection
- Dynamic compression format handling based on media type suffixes
- Proper file extension mapping (`.tar.gz`, `.tar.zst`, `.tar`)

### Compression Detection
Uses suffix matching to identify formats:
- `+gzip` suffix → gzip compression
- `+zstd` suffix → zstd compression  
- `.tar` suffix → uncompressed tar
- `.raw` suffix → raw files (no extraction)
- Default → gzip (backward compatibility)

### Dependencies
- Optional: `pip install zstandard` for zstd support