### PR TITLE
If failed to get credential - inform on what input, and use stdout if no stderr

### DIFF
--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -66,10 +66,11 @@ class AuthBackend:
 
     def _get_auth_from_creds_store(self, suffix: str, hostname: str) -> Optional[str]:
         binary = f"docker-credential-{suffix}"
+        stdin = hostname
         try:
             proc = subprocess.run(
                 [binary, "get"],
-                input=hostname.encode(),
+                input=stdin.encode(),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
@@ -79,7 +80,8 @@ class AuthBackend:
             return None
         except subprocess.CalledProcessError as exc:
             logger.warning(
-                f"Credential helper '{binary}' failed: {exc.stderr.decode().strip()}"
+                f"Credential helper '{binary}' for {stdin!r} failed: "
+                f"{(exc.stderr or exc.stdout).decode().strip()}"
             )
             return None
         payload = json.loads(proc.stdout)


### PR DESCRIPTION
In my case I was trying with such a minimal usecase

    import oras.client
    from oras.container import Container

    client = oras.client.OrasClient()
    container = Container("neurodebian:sid")
    client.get_manifest(container)

and I had

    ❯ docker-credential-secretservice list
    {"https://index.docker.io/v1/":"repronimservices","workshop.dev.flywheel.io":"yarikoptic@gmail.com"}

Running the script resulted in hard to digest and not very informative traceback which started with

    ❯ uv run try_oras.py
    Credential helper 'docker-credential-secretservice' failed:

NB it then continued with not directly related traceback on JSONDecodeError because was returned HTML I guess instead of json... not clear why continued to start with.

Not yet sure how the "input" should be fixed up (but seems need to be a url not just hostname), but this PR fixes at least the error to become informative. With it we get:

    Credential helper 'docker-credential-secretservice' for 'docker.io' failed: credentials not found in native keychain

FTR:

	❯ dlocate docker-credential-secretservice
	golang-docker-credential-helpers: /usr/bin/docker-credential-secretservice
	❯ apt-cache policy golang-docker-credential-helpers | cat
	golang-docker-credential-helpers:
	  Installed: 0.6.4+ds1-1+b18
	  Candidate: 0.6.4+ds1-1+b18
	  Version table:
	 *** 0.6.4+ds1-1+b18 900
			600 https://deb.debian.org/debian sid/main amd64 Packages
			900 https://deb.debian.org/debian forky/main amd64 Packages
			100 https://deb.debian.org/debian trixie/main amd64 Packages
			100 /var/lib/dpkg/status