### PR TITLE
feat: add Layout `copy` for pull_from_registry capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - add Layout `copy` for pull_from_registry capability (0.2.42)
  - make `get_manifest()` validation optional, fix `Accept` header join, and expand default `Accept` header types to cover all supported response types for the `/v2/<name>/manifests/<reference>` endpoint (0.2.41)
  - fix preemptive exit in non-empty `auths` lookup when `credsStore` or `credHelpers` is used (0.2.40)
  - introduce API to copy from oci-layout to OCI registry (0.2.39)

--- a/oras/layout/__init__.py
+++ b/oras/layout/__init__.py
@@ -1,3 +1,3 @@
-from .layout import Layout, NewLayout
+from .layout import Layout, NewLayout, NewLayoutFromRegistry
 
-__all__ = ["Layout", "NewLayout"]
+__all__ = ["Layout", "NewLayout", "NewLayoutFromRegistry"]

--- a/oras/layout/layout.py
+++ b/oras/layout/layout.py
@@ -19,7 +19,7 @@ from oras.layout.validation import (
     _validate_oci_layout_file,
 )
 from oras.logger import logger
-from oras.utils.fileio import read_json
+from oras.utils.fileio import read_json, write_json
 
 if TYPE_CHECKING:
     from oras.provider import Registry
@@ -39,6 +39,45 @@ def NewLayout(path: str, validate: bool = True) -> Layout:
     :raises ValueError: if path is not a directory, or validation fails (when validate=True)
     """
     return Layout(path=path, validate=validate)
+
+
+def NewLayoutFromRegistry(
+    path: str,
+    provider: Registry,
+    target: str,
+    tag: str = "latest",
+) -> Layout:
+    """
+    Create a new OCI Layout on disk by pulling from a remote registry.
+
+    The path must either not exist or be an empty directory.
+
+    :param path: path to create the Layout directory
+    :type path: str
+    :param provider: Registry provider instance for downloading
+    :type provider: oras.provider.Registry
+    :param target: source registry/repository with tag or digest
+        (e.g., "ghcr.io/user/repo:v1.0" or "ghcr.io/user/repo@sha256:abc123...")
+    :type target: str
+    :param tag: tag to write in the layout's index.json annotation (default: "latest")
+    :type tag: str
+    :return: Layout instance for the pulled Layout directory
+    :rtype: Layout
+    :raises FileExistsError: if path exists and is not an empty directory
+    :raises ValueError: if path exists but is not a directory
+    """
+    p = pathlib.Path(path)
+    if p.exists():
+        if not p.is_dir():
+            raise ValueError(f"Path exists and is not a directory: {path}")
+        if any(p.iterdir()):
+            raise FileExistsError(f"Directory is not empty: {path}")
+    else:
+        p.mkdir(parents=True)
+
+    layout = Layout(path=path, validate=False)
+    layout.pull_from_registry(provider=provider, target=target, tag=tag)
+    return layout
 
 
 class Layout:
@@ -136,20 +175,13 @@ class Layout:
 
         # Collect blobs in dependency order
         collected = []
-        Layout._process_manifest(
-            pathlib.Path(self._oci_layout_path), target_digest, collected
-        )
+        self._process_manifest(target_digest, collected)
         return collected
 
-    @staticmethod
-    def _process_manifest(
-        layout_dir: pathlib.Path, digest: str, collected: list[str]
-    ) -> None:
+    def _process_manifest(self, digest: str, collected: list[str]) -> None:
         """
         Recursively process a manifest blob and collect dependencies.
 
-        :param layout_dir: path to OCI layout directory
-        :type layout_dir: pathlib.Path
         :param digest: digest of manifest to process (with algorithm prefix)
         :type digest: str
         :param collected: list to accumulate digests (mutated in place)
@@ -157,9 +189,7 @@ class Layout:
         :raises FileNotFoundError: if blob file doesn't exist
         :raises ValueError: if manifest structure is invalid
         """
-        # Construct blob path: blobs/sha256/abc123...
-        algorithm, hash_value = digest.split(":", 1)
-        blob_path = layout_dir / oras.defaults.oci_blobs_dir / algorithm / hash_value
+        blob_path = self.digest_to_blob_path(digest)
 
         if not blob_path.exists():
             raise FileNotFoundError(f"Blob not found: {blob_path}")
@@ -184,7 +214,7 @@ class Layout:
         elif media_type == oras.defaults.default_index_media_type:
             # Image index: recurse on sub-manifests, then add index itself
             for sub_manifest in manifest.get("manifests", []):
-                Layout._process_manifest(layout_dir, sub_manifest["digest"], collected)
+                self._process_manifest(sub_manifest["digest"], collected)
 
             if digest not in collected:
                 collected.append(digest)
@@ -195,20 +225,33 @@ class Layout:
                 f"Expected '{oras.defaults.default_manifest_media_type}' or '{oras.defaults.default_index_media_type}'"
             )
 
-    @staticmethod
-    def _digest_to_blob_path(layout_dir: pathlib.Path, digest: str) -> pathlib.Path:
+    def digest_to_blob_path(self, digest: str) -> pathlib.Path:
         """
         Convert digest string (usually `sha256:abc123`) to blob file path in OCI layout.
 
-        :param layout_dir: path to OCI layout directory
-        :type layout_dir: pathlib.Path
         :param digest: digest with algorithm prefix (e.g., "sha256:abc123...")
         :type digest: str
         :return: path to blob file (e.g., layout_dir/blobs/sha256/abc123...)
         :rtype: pathlib.Path
         """
         algorithm, hash_value = digest.split(":", 1)
-        return layout_dir / oras.defaults.oci_blobs_dir / algorithm / hash_value
+        return (
+            pathlib.Path(self._oci_layout_path)
+            / oras.defaults.oci_blobs_dir
+            / algorithm
+            / hash_value
+        )
+
+    def blob_exists(self, digest: str) -> bool:
+        """
+        Check if a blob already exists in the OCI layout on disk.
+
+        :param digest: digest with algorithm prefix (e.g., "sha256:abc123...")
+        :type digest: str
+        :return: True if blob file exists on disk
+        :rtype: bool
+        """
+        return self.digest_to_blob_path(digest).exists()
 
     @staticmethod
     def _create_layer_dict(
@@ -232,6 +275,136 @@ class Layout:
             "size": size,
             "mediaType": media_type or oras.defaults.unknown_config_media_type,
         }
+
+    def _pull_manifest_blobs(
+        self,
+        provider: Registry,
+        container,
+        manifest_data: dict,
+        manifest_digest: str,
+        manifest_bytes: bytes,
+    ) -> None:
+        """
+        Download all blobs referenced by an Image Manifest and store them in the OCI layout.
+
+        Downloads layer blobs and config blob via the registry blob endpoint,
+        then stores the manifest itself from its already-fetched raw bytes.
+        Skips blobs that already exist on disk (deduplication).
+
+        :param provider: Registry provider instance for downloading
+        :type provider: oras.provider.Registry
+        :param container: parsed container URI
+        :type container: oras.container.Container
+        :param manifest_data: parsed manifest JSON
+        :type manifest_data: dict
+        :param manifest_digest: digest of the manifest (with algorithm prefix)
+        :type manifest_digest: str
+        :param manifest_bytes: raw bytes of the manifest
+        :type manifest_bytes: bytes
+        """
+        # layer blobs
+        for layer in manifest_data.get("layers", []):
+            layer_digest = layer["digest"]
+            if not self.blob_exists(layer_digest):
+                provider.download_blob(
+                    container,
+                    layer_digest,
+                    str(self.digest_to_blob_path(layer_digest)),
+                )
+                logger.debug(f"Downloaded layer blob: {layer_digest}")
+
+        # config blob
+        config_digest = manifest_data.get("config", {}).get("digest")
+        if config_digest and not self.blob_exists(config_digest):
+            provider.download_blob(
+                container,
+                config_digest,
+                str(self.digest_to_blob_path(config_digest)),
+            )
+            logger.debug(f"Downloaded config blob: {config_digest}")
+
+        # manifest blob (raw bytes coming from manifest endpoint fetch)
+        if not self.blob_exists(manifest_digest):
+            blob_path = self.digest_to_blob_path(manifest_digest)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)  # ensures blobs/<algo>/
+            blob_path.write_bytes(manifest_bytes)
+            logger.debug(f"Stored manifest blob: {manifest_digest}")
+
+    def _pull_index_blobs(
+        self,
+        provider: Registry,
+        container,
+        index_data: dict,
+        index_digest: str,
+        index_bytes: bytes,
+    ) -> None:
+        """
+        Download all content referenced by an Image Index and store in the OCI layout.
+
+        Iterates sub-manifests, fetches each by digest from the registry,
+        and recursively processes them. Handles nested indexes.
+        Skips blobs that already exist on disk (deduplication).
+
+        :param provider: Registry provider instance for downloading
+        :type provider: oras.provider.Registry
+        :param container: parsed container URI
+        :type container: oras.container.Container
+        :param index_data: parsed index JSON
+        :type index_data: dict
+        :param index_digest: digest of the index (with algorithm prefix)
+        :type index_digest: str
+        :param index_bytes: raw bytes of the index
+        :type index_bytes: bytes
+        :raises ValueError: if a sub-manifest has an unsupported mediaType
+        """
+        for sub_manifest_ref in index_data.get("manifests", []):
+            sub_digest = sub_manifest_ref["digest"]
+            if self.blob_exists(sub_digest):
+                continue
+
+            logger.debug(f"Fetching sub-manifest: {sub_digest}")
+            sub_media_type = sub_manifest_ref.get(
+                "mediaType", oras.defaults.default_manifest_media_type
+            )
+            headers = {"Accept": sub_media_type}
+            sub_url = f"{provider.prefix}://{container.registry}/v2/{container.api_prefix}/manifests/{sub_digest}"
+            response = provider.do_request(sub_url, "GET", headers=headers)
+            provider._check_200_response(response)
+
+            sub_bytes = response.content
+            sub_data = json.loads(sub_bytes)
+            # the Index might have defaulted, so we overwrite with the actual content response
+            sub_media_type = sub_data.get("mediaType", "")
+
+            if sub_media_type == oras.defaults.default_manifest_media_type:
+                self._pull_manifest_blobs(
+                    provider,
+                    container,
+                    sub_data,
+                    sub_digest,
+                    sub_bytes,
+                )
+            elif sub_media_type == oras.defaults.default_index_media_type:
+                # nested index; rare but valid: https://github.com/opencontainers/image-spec/blob/6529f89e290d8169adbddf15e43493b9fdd37b62/image-index.md?plain=1#L40-L46
+                self._pull_index_blobs(
+                    provider,
+                    container,
+                    sub_data,
+                    sub_digest,
+                    sub_bytes,
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported manifest mediaType in index: {sub_media_type}. "
+                    f"Expected '{oras.defaults.default_manifest_media_type}' or '{oras.defaults.default_index_media_type}'"
+                )
+
+        # store the index blob itself
+        if not self.blob_exists(index_digest):
+            blob_path = self.digest_to_blob_path(index_digest)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)  # ensures blobs/<algo>/
+            blob_path.write_bytes(index_bytes)
+            logger.debug(f"Stored index blob: {index_digest}")
 
     def push_to_registry(
         self,
@@ -271,9 +444,7 @@ class Layout:
         # Upload blobs in dependency order
         last_response = None
         for i, digest in enumerate(ordered_blobs):
-            blob_path = Layout._digest_to_blob_path(
-                pathlib.Path(self._oci_layout_path), digest
-            )
+            blob_path = self.digest_to_blob_path(digest)
 
             # Verify blob exists (we don't have this check by spec in validation_oci_layout)
             if not blob_path.exists():
@@ -347,3 +518,100 @@ class Layout:
 
         logger.debug(f"Successfully pushed {len(ordered_blobs)} blobs to {target}")
         return last_response
+
+    def pull_from_registry(
+        self,
+        provider: Registry,
+        target: str,
+        tag: str = "latest",
+    ) -> None:
+        """
+        Pull an OCI artifact from a remote registry into this OCI layout directory,
+        overwriting the oci-layout index file.
+
+        Creates a valid OCI Layout on disk at this oci-layout's path,
+        downloading all referenced blobs (layers, configs, manifests).
+        Handles both single Image Manifests and Indexes.
+
+        :param provider: Registry provider instance for downloading
+        :type provider: oras.provider.Registry
+        :param target: source registry/repository with tag or digest
+            (e.g., "ghcr.io/user/repo:v1.0" or "ghcr.io/user/repo@sha256:abc123...")
+        :type target: str
+        :param tag: tag to write in the layout's index.json annotation (default: "latest")
+        :type tag: str
+        :raises ValueError: if target is invalid or manifest has unsupported mediaType
+        """
+        container = provider.get_container(target)
+        layout_dir = pathlib.Path(self._oci_layout_path)
+
+        # prepare directory structure for blobs
+        blobs_dir = layout_dir / oras.defaults.oci_blobs_dir / "sha256"
+        blobs_dir.mkdir(parents=True, exist_ok=True)
+
+        headers = {
+            "Accept": ", ".join(oras.defaults.default_manifest_accepted_media_types)
+        }
+        manifest_url = f"{provider.prefix}://{container.manifest_url()}"
+        response = provider.do_request(manifest_url, "GET", headers=headers)
+        provider._check_200_response(response)
+
+        manifest_bytes = response.content
+        manifest_digest = response.headers.get(
+            "Docker-Content-Digest", container.digest
+        )
+        if not manifest_digest:
+            raise RuntimeError(
+                "Expected to find Docker-Content-Digest header in manifest response."
+            )
+        manifest_data = json.loads(manifest_bytes)
+        media_type = manifest_data.get("mediaType", "")
+
+        logger.debug(
+            f"Pulling {target} (mediaType={media_type}, digest={manifest_digest}) to OCI layout"
+        )
+        if media_type == oras.defaults.default_manifest_media_type:
+            self._pull_manifest_blobs(
+                provider,
+                container,
+                manifest_data,
+                manifest_digest,
+                manifest_bytes,
+            )
+        elif media_type == oras.defaults.default_index_media_type:
+            self._pull_index_blobs(
+                provider,
+                container,
+                manifest_data,
+                manifest_digest,
+                manifest_bytes,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported manifest mediaType: {media_type}. "
+                f"Expected '{oras.defaults.default_manifest_media_type}' or '{oras.defaults.default_index_media_type}'"
+            )
+
+        # oci-layout file
+        oci_layout_content = {
+            "imageLayoutVersion": oras.defaults.oci_layout_version_pin
+        }
+        write_json(oci_layout_content, str(layout_dir / oras.defaults.oci_layout_file))
+
+        # index.json
+        index_entry = {
+            "mediaType": media_type,
+            "digest": manifest_digest,
+            "size": len(manifest_bytes),
+            "annotations": {oras.defaults.oci_ref_name_annotation: tag},
+        }
+        index_content = {
+            "schemaVersion": oras.defaults.oci_index_schema_version,
+            "manifests": [index_entry],
+        }
+        jsonschema.validate(index_content, schema=oras.schemas.index)
+        write_json(index_content, str(layout_dir / oras.defaults.oci_image_index_file))
+
+        logger.debug(
+            f"Successfully pulled {target} to OCI layout at {self._oci_layout_path}"
+        )

--- a/oras/tests/test_layout.py
+++ b/oras/tests/test_layout.py
@@ -9,7 +9,7 @@ import pytest
 import oras.client
 import oras.provider
 import oras.utils as utils
-from oras.layout import Layout, NewLayout
+from oras.layout import Layout, NewLayout, NewLayoutFromRegistry
 
 
 def test_validate_oci_layout_valid_minimal(tmp_path):
@@ -572,6 +572,34 @@ def test_get_ordered_blobs_tag_not_found():
         Layout(layout_path).get_ordered_blobs("nonexistent")
 
 
+def test_blob_exists():
+    """Test blob_exists returns True for blobs on disk and False otherwise"""
+    layout = Layout(str(pathlib.Path(__file__).parent / "ocilayout_data/ocilayout1"))
+
+    # known blobs from ocilayout1
+    assert (
+        layout.blob_exists(
+            "sha256:cfcb44ade8c9b2579247ceec82c2f18bf03d956b9b2c050753b7d47d1edd369d",
+        )
+        is True
+    )
+    assert (
+        layout.blob_exists(
+            "sha256:6a315ec0732bc64a9763b6da6df8326f836c3661991c8ba3f5e83e1ad4fd57b7",
+        )
+        is True
+    )
+    assert (
+        layout.blob_exists(
+            "sha256:1a88c78449cd2ce9961de409273deac250a60e55b1d8c4beef858b8618ddaba5",
+        )
+        is True
+    )
+
+    # non-existent blobs
+    assert layout.blob_exists("sha256:0000000000000000") is False
+
+
 @pytest.mark.with_auth(False)
 def test_push_from_layout_single_arch(
     registry, credentials, target_layout_single
@@ -672,3 +700,215 @@ def test_push_from_layout_invalid_tag(
             target=target,
             tag="nonexistent",  # This tag doesn't exist in ocilayout1's index.json
         )
+
+
+@pytest.mark.with_auth(False)
+def test_pull_to_layout_single_arch(
+    registry, credentials, target_layout_single, tmp_path
+):  # using `with_auth` marker requires `credentials` fixture
+    """
+    Round-trip test: push single-arch OCI layout to registry, pull back to temp dir, compare.
+    Requires running registry (ORAS_HOST and ORAS_PORT env variables).
+    """
+    source_layout_path = str(
+        pathlib.Path(__file__).parent / "ocilayout_data/ocilayout1"
+    )
+    provider = oras.provider.Registry(insecure=True)
+    Layout(source_layout_path).push_to_registry(
+        provider=provider,
+        target=target_layout_single,
+        tag="latest",
+    )
+
+    pull_dir = str(tmp_path / "pulled_layout")
+    pulled_layout = Layout(pull_dir, validate=False)
+    pulled_layout.pull_from_registry(
+        provider=provider,
+        target=target_layout_single,
+        tag="latest",
+    )
+
+    pulled_layout.validate()
+    source_blobs = sorted(Layout(source_layout_path).get_ordered_blobs("latest"))
+    pulled_blobs = sorted(Layout(pull_dir).get_ordered_blobs("latest"))
+    assert source_blobs == pulled_blobs
+
+    # compare test oci-layout with Pulled tmp oci-layout bytewise
+    source_layout = Layout(source_layout_path)
+    pulled_layout_check = Layout(pull_dir)
+    for digest in source_blobs:
+        source_path = source_layout.digest_to_blob_path(digest)
+        pulled_path = pulled_layout_check.digest_to_blob_path(digest)
+        assert pulled_path.exists(), f"Pulled layout missing blob: {digest}"
+        assert (
+            source_path.read_bytes() == pulled_path.read_bytes()
+        ), f"Blob content mismatch: {digest}"
+
+
+@pytest.mark.with_auth(False)
+def test_pull_to_layout_multi_arch(
+    registry, credentials, target_layout_multi, tmp_path
+):  # using `with_auth` marker requires `credentials` fixture
+    """
+    Round-trip test: push multi-arch OCI layout to registry, pull back to temp dir, compare.
+    Requires running registry (ORAS_HOST and ORAS_PORT env variables).
+    """
+    source_layout_path = str(
+        pathlib.Path(__file__).parent / "ocilayout_data/ocilayout2"
+    )
+    provider = oras.provider.Registry(insecure=True)
+    Layout(source_layout_path).push_to_registry(
+        provider=provider,
+        target=target_layout_multi,
+        tag="latest",
+    )
+
+    pull_dir = str(tmp_path / "pulled_layout")
+    pulled_layout = Layout(pull_dir, validate=False)
+    pulled_layout.pull_from_registry(
+        provider=provider,
+        target=target_layout_multi,
+        tag="latest",
+    )
+
+    pulled_layout.validate()
+    source_blobs = sorted(Layout(source_layout_path).get_ordered_blobs("latest"))
+    pulled_blobs = sorted(Layout(pull_dir).get_ordered_blobs("latest"))
+    assert source_blobs == pulled_blobs
+    assert len(pulled_blobs) == len(set(pulled_blobs))
+
+    # compare test oci-layout with Pulled tmp oci-layout bytewise
+    source_layout = Layout(source_layout_path)
+    pulled_layout_check = Layout(pull_dir)
+    for digest in source_blobs:
+        source_path = source_layout.digest_to_blob_path(digest)
+        pulled_path = pulled_layout_check.digest_to_blob_path(digest)
+        assert pulled_path.exists(), f"Pulled layout missing blob: {digest}"
+        assert (
+            source_path.read_bytes() == pulled_path.read_bytes()
+        ), f"Blob content mismatch: {digest}"
+
+
+def test_pull_from_registry_invalid_target(tmp_path):
+    """
+    Test error handling when pulling with a malformed target.
+    """
+    provider = oras.provider.Registry(insecure=True)
+    pull_dir = str(tmp_path / "pulled_layout")
+    pulled_layout = Layout(pull_dir, validate=False)
+
+    with pytest.raises(ValueError, match="does not match"):
+        pulled_layout.pull_from_registry(
+            provider=provider,
+            target="",
+        )
+
+
+@pytest.mark.with_auth(False)
+def test_pull_to_layout_custom_tag(
+    registry, credentials, target_layout_single, tmp_path
+):  # using `with_auth` marker requires `credentials` fixture
+    """
+    Test that the tag parameter controls the annotation written in the pulled layout's index.json.
+    Requires running registry (ORAS_HOST and ORAS_PORT env variables).
+    """
+    source_layout_path = str(
+        pathlib.Path(__file__).parent / "ocilayout_data/ocilayout1"
+    )
+    provider = oras.provider.Registry(insecure=True)
+    Layout(source_layout_path).push_to_registry(
+        provider=provider,
+        target=target_layout_single,
+        tag="latest",
+    )
+
+    pull_dir = str(tmp_path / "pulled_layout")
+    pulled_layout = Layout(pull_dir, validate=False)
+    pulled_layout.pull_from_registry(
+        provider=provider,
+        target=target_layout_single,
+        tag="my-custom-tag",
+    )
+
+    index_data = utils.read_json(str(pathlib.Path(pull_dir) / "index.json"))
+    annotations = index_data["manifests"][0]["annotations"]
+    assert annotations["org.opencontainers.image.ref.name"] == "my-custom-tag"
+    source_blobs = sorted(Layout(source_layout_path).get_ordered_blobs("latest"))
+    pulled_blobs = sorted(Layout(pull_dir).get_ordered_blobs("my-custom-tag"))
+    assert source_blobs == pulled_blobs
+
+    # compare test oci-layout with Pulled tmp oci-layout bytewise
+    source_layout = Layout(source_layout_path)
+    pulled_layout_check = Layout(pull_dir)
+    for digest in source_blobs:
+        source_path = source_layout.digest_to_blob_path(digest)
+        pulled_path = pulled_layout_check.digest_to_blob_path(digest)
+        assert pulled_path.exists(), f"Pulled layout missing blob: {digest}"
+        assert (
+            source_path.read_bytes() == pulled_path.read_bytes()
+        ), f"Blob content mismatch: {digest}"
+
+
+def test_new_layout_from_registry_rejects_non_empty_dir(tmp_path):
+    """NewLayoutFromRegistry should reject a non-empty directory."""
+    (tmp_path / "somefile.txt").write_text("Hello, World!")
+    provider = oras.provider.Registry(insecure=True)
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        NewLayoutFromRegistry(
+            str(tmp_path), provider=provider, target="localhost:5000/repo:v1"
+        )
+
+
+def test_new_layout_from_registry_rejects_file_path(tmp_path):
+    """NewLayoutFromRegistry should reject a path that is a file."""
+    file_path = tmp_path / "afile"
+    file_path.write_text("Hello, World!")
+    provider = oras.provider.Registry(insecure=True)
+
+    with pytest.raises(ValueError, match="not a directory"):
+        NewLayoutFromRegistry(
+            str(file_path), provider=provider, target="localhost:5000/repo:v1"
+        )
+
+
+@pytest.mark.with_auth(False)
+def test_pull_to_layout_by_digest(
+    registry, credentials, target_layout_single, tmp_path
+):  # using `with_auth` marker requires `credentials` fixture
+    """
+    Test pulling by digest reference (repo@sha256:...) instead of tag,
+    using the factory NewLayoutFromRegistry.
+    Requires running registry (ORAS_HOST and ORAS_PORT env variables).
+    """
+    source_layout_path = str(
+        pathlib.Path(__file__).parent / "ocilayout_data/ocilayout1"
+    )
+    provider = oras.provider.Registry(insecure=True)
+    push_response = Layout(source_layout_path).push_to_registry(
+        provider=provider,
+        target=target_layout_single,
+        tag="latest",
+    )
+
+    # construct a digest-based reference from the Push response
+    digest = push_response.headers["Docker-Content-Digest"]
+    ref_without_tag = target_layout_single.rsplit(":", 1)[0]
+    digest_ref = f"{ref_without_tag}@{digest}"
+
+    # now Pull using the digest reference via the factory
+    pull_dir = str(tmp_path / "pulled_layout")
+    pulled_layout = NewLayoutFromRegistry(
+        pull_dir, provider=provider, target=digest_ref
+    )
+
+    pulled_layout.validate()
+    source_blobs = sorted(Layout(source_layout_path).get_ordered_blobs("latest"))
+    pulled_blobs = sorted(pulled_layout.get_ordered_blobs("latest"))
+    assert source_blobs == pulled_blobs
+    # compare test oci-layout with Pulled tmp oci-layout bytewise
+    source_layout = Layout(source_layout_path)
+    for d in source_blobs:
+        source_path = source_layout.digest_to_blob_path(d)
+        pulled_path = pulled_layout.digest_to_blob_path(d)
+        assert source_path.read_bytes() == pulled_path.read_bytes()

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.41"
+__version__ = "0.2.42"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
- follow up on previous PR for copy, now allow Pull (from Registry to OCI Layout)
  - https://github.com/oras-project/oras-py/pull/228
- re-use code and code-conventions
  - made sure I didn't leave any single-use variables (as requested previously)
  - re-used utilities for json serde
  - re-used naturally what was made previously in https://github.com/oras-project/oras-py/pull/228 as possible
  - reason for parameter called `pull_from_registry(...  target: str, ...)` is to make it consistent with [analogous use in provider](https://github.com/oras-project/oras-py/blob/e51bc875f8eee6a120e7fb873362439194ec2eb4/oras/provider.py#L871)
- introduced `NewLayoutFromRegistry` convenience/factory method (as analogously requested previously)
- naturally test coverage, re-using fixture and style as possible

Hope this is helpful! 🙏 🚀 

cc @vsoch  @astefanutti 