### PR TITLE
Add content verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
- - validate pulled blob size and digest before writing or extracting content (0.2.43)
+ - validate pulled blob and manifest content before writing, parsing, or extracting it (0.2.43)
  - add Layout `copy` for pull_from_registry capability (0.2.42)
  - make `get_manifest()` validation optional, fix `Accept` header join, and expand default `Accept` header types to cover all supported response types for the `/v2/<name>/manifests/<reference>` endpoint (0.2.41)
  - fix preemptive exit in non-empty `auths` lookup when `credsStore` or `credHelpers` is used (0.2.40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - validate pulled blob size and digest before writing or extracting content (0.2.43)
  - add Layout `copy` for pull_from_registry capability (0.2.42)
  - make `get_manifest()` validation optional, fix `Accept` header join, and expand default `Accept` header types to cover all supported response types for the `/v2/<name>/manifests/<reference>` endpoint (0.2.41)
  - fix preemptive exit in non-empty `auths` lookup when `credsStore` or `credHelpers` is used (0.2.40)

--- a/oras/layout/layout.py
+++ b/oras/layout/layout.py
@@ -371,7 +371,7 @@ class Layout:
             sub_media_type = sub_manifest_ref.get(
                 "mediaType", oras.defaults.default_manifest_media_type
             )
-            response, verified_digest = provider._get_manifest_response(
+            sub_bytes, verified_digest = provider._get_manifest_bytes(
                 container,
                 allowed_media_type=[sub_media_type],
                 reference=sub_digest,
@@ -379,7 +379,6 @@ class Layout:
                 expected_size=sub_size,
             )
 
-            sub_bytes = response.content
             sub_data = json.loads(sub_bytes)
             sub_digest = str(verified_digest)
             # the Index might have defaulted, so we overwrite with the actual content response
@@ -558,13 +557,12 @@ class Layout:
         blobs_dir = layout_dir / oras.defaults.oci_blobs_dir / "sha256"
         blobs_dir.mkdir(parents=True, exist_ok=True)
 
-        response, verified_digest = provider._get_manifest_response(
+        manifest_bytes, verified_digest = provider._get_manifest_bytes(
             container,
             allowed_media_type=oras.defaults.default_manifest_accepted_media_types,
             expected_digest=container.digest,
         )
 
-        manifest_bytes = response.content
         manifest_digest = str(verified_digest)
         manifest_data = json.loads(manifest_bytes)
         media_type = manifest_data.get("mediaType", "")

--- a/oras/layout/layout.py
+++ b/oras/layout/layout.py
@@ -305,21 +305,25 @@ class Layout:
         # layer blobs
         for layer in manifest_data.get("layers", []):
             layer_digest = layer["digest"]
+            layer_size = layer["size"]
             if not self.blob_exists(layer_digest):
                 provider.download_blob(
                     container,
                     layer_digest,
                     str(self.digest_to_blob_path(layer_digest)),
+                    layer_size,
                 )
                 logger.debug(f"Downloaded layer blob: {layer_digest}")
 
         # config blob
         config_digest = manifest_data.get("config", {}).get("digest")
+        config_size = manifest_data.get("config", {}).get("size")
         if config_digest and not self.blob_exists(config_digest):
             provider.download_blob(
                 container,
                 config_digest,
                 str(self.digest_to_blob_path(config_digest)),
+                config_size,
             )
             logger.debug(f"Downloaded config blob: {config_digest}")
 

--- a/oras/layout/layout.py
+++ b/oras/layout/layout.py
@@ -367,16 +367,21 @@ class Layout:
                 continue
 
             logger.debug(f"Fetching sub-manifest: {sub_digest}")
+            sub_size = sub_manifest_ref["size"]
             sub_media_type = sub_manifest_ref.get(
                 "mediaType", oras.defaults.default_manifest_media_type
             )
-            headers = {"Accept": sub_media_type}
-            sub_url = f"{provider.prefix}://{container.registry}/v2/{container.api_prefix}/manifests/{sub_digest}"
-            response = provider.do_request(sub_url, "GET", headers=headers)
-            provider._check_200_response(response)
+            response, verified_digest = provider._get_manifest_response(
+                container,
+                allowed_media_type=[sub_media_type],
+                reference=sub_digest,
+                expected_digest=sub_digest,
+                expected_size=sub_size,
+            )
 
             sub_bytes = response.content
             sub_data = json.loads(sub_bytes)
+            sub_digest = str(verified_digest)
             # the Index might have defaulted, so we overwrite with the actual content response
             sub_media_type = sub_data.get("mediaType", "")
 
@@ -553,21 +558,14 @@ class Layout:
         blobs_dir = layout_dir / oras.defaults.oci_blobs_dir / "sha256"
         blobs_dir.mkdir(parents=True, exist_ok=True)
 
-        headers = {
-            "Accept": ", ".join(oras.defaults.default_manifest_accepted_media_types)
-        }
-        manifest_url = f"{provider.prefix}://{container.manifest_url()}"
-        response = provider.do_request(manifest_url, "GET", headers=headers)
-        provider._check_200_response(response)
+        response, verified_digest = provider._get_manifest_response(
+            container,
+            allowed_media_type=oras.defaults.default_manifest_accepted_media_types,
+            expected_digest=container.digest,
+        )
 
         manifest_bytes = response.content
-        manifest_digest = response.headers.get(
-            "Docker-Content-Digest", container.digest
-        )
-        if not manifest_digest:
-            raise RuntimeError(
-                "Expected to find Docker-Content-Digest header in manifest response."
-            )
+        manifest_digest = str(verified_digest)
         manifest_data = json.loads(manifest_bytes)
         media_type = manifest_data.get("mediaType", "")
 

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -191,7 +191,7 @@ class RegisteredDigestAlgorithm(enum.Enum):
     SHA256 = "sha256"
     SHA512 = "sha512"
 
-    def hash_path(self, path: str) -> "Digest":
+    def digest_for_path(self, path: str) -> "Digest":
         hasher = self.hasher()
         with open(path, "rb") as file:
             for chunk in iter(lambda: file.read(8192), b""):

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -227,14 +227,12 @@ class Digest:
             raise ValueError(
                 f"Unsupported OCI digest algorithm: {algorithm}."
             ) from error
-        encoded = match.group("encoded")
-        encoded_length = registered_algorithm.hash_size * 2
-        if encoded_length is None:
-            raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.")
 
-        if len(encoded) == encoded_length:
+        encoded = match.group("encoded")
+        expected_length = registered_algorithm.hash_size * 2
+        if len(encoded) != expected_length:
             raise ValueError(
-                f"Invalid {algorithm} digest encoding: expected {encoded_length} "
+                f"Invalid {algorithm} digest encoding: expected {expected_length} "
                 "lowercase hexadecimal characters."
             )
 

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -20,6 +20,7 @@ import oras.utils
 _DIGEST_PATTERN = re.compile(
     r"^(?P<algorithm>[a-z0-9]+(?:[+._-][a-z0-9]+)*):" r"(?P<encoded>[a-zA-Z0-9=_-]+)$"
 )
+_HEX_DIGEST_PATTERN = re.compile(r"[a-f0-9]+")
 
 
 EmptyManifest = {
@@ -235,7 +236,10 @@ class Digest:
 
         encoded = match.group("encoded")
         expected_length = registered_algorithm.hash_size * 2
-        if len(encoded) != expected_length:
+        if (
+            len(encoded) != expected_length
+            or _HEX_DIGEST_PATTERN.fullmatch(encoded) is None
+        ):
             raise ValueError(
                 f"Invalid {algorithm} digest encoding: expected {expected_length} "
                 "lowercase hexadecimal characters."

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -3,17 +3,24 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import copy
+import enum
 import hashlib
 import json
 import os
+import re
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import jsonschema
 
 import oras.defaults
 import oras.schemas
 import oras.utils
+
+_DIGEST_PATTERN = re.compile(
+    r"^(?P<algorithm>[a-z0-9]+(?:[+._-][a-z0-9]+)*):" r"(?P<encoded>[a-zA-Z0-9=_-]+)$"
+)
+
 
 EmptyManifest = {
     "schemaVersion": 2,
@@ -178,3 +185,69 @@ class Subject:
             digest,
             size,
         )
+
+
+class RegisteredDigestAlgorithm(enum.Enum):
+    SHA256 = "sha256"
+    SHA512 = "sha512"
+
+    def hash_path(self, path: str) -> "Digest":
+        hasher = self.hasher()
+        with open(path, "rb") as file:
+            for chunk in iter(lambda: file.read(8192), b""):
+                hasher.update(chunk)
+        return Digest(f"{self.value}:{hasher.hexdigest()}")
+
+    def hasher(self) -> Any:
+        try:
+            return hashlib.new(self.value)
+        except ValueError as error:
+            raise ValueError(f"Unsupported OCI digest algorithm: {self}.") from error
+
+    @property
+    def hash_size(self) -> int:
+        return self.hasher().digest_size
+
+
+class Digest:
+    def __init__(self, digest: str) -> None:
+        self.algorithm, self.encoded = self._parse_digest(digest)
+
+    @staticmethod
+    def _parse_digest(digest: str) -> Tuple[RegisteredDigestAlgorithm, str]:
+        """Parse and validate an OCI digest's algorithm and encoded value."""
+        match = _DIGEST_PATTERN.fullmatch(digest)
+        if not match:
+            raise ValueError(f"Invalid OCI digest: {digest!r}.")
+
+        algorithm = match.group("algorithm")
+        try:
+            registered_algorithm = RegisteredDigestAlgorithm(algorithm)
+        except ValueError as error:
+            raise ValueError(
+                f"Unsupported OCI digest algorithm: {algorithm}."
+            ) from error
+        encoded = match.group("encoded")
+        encoded_length = registered_algorithm.hash_size * 2
+        if encoded_length is None:
+            raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.")
+
+        if len(encoded) == encoded_length:
+            raise ValueError(
+                f"Invalid {algorithm} digest encoding: expected {encoded_length} "
+                "lowercase hexadecimal characters."
+            )
+
+        return registered_algorithm, encoded
+
+    @property
+    def digest(self) -> str:
+        return f"{self.algorithm.value}:{self.encoded}"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Digest):
+            return self.digest == other.digest
+        return False
+
+    def __str__(self) -> str:
+        return self.digest

--- a/oras/oci.py
+++ b/oras/oci.py
@@ -191,6 +191,11 @@ class RegisteredDigestAlgorithm(enum.Enum):
     SHA256 = "sha256"
     SHA512 = "sha512"
 
+    def digest_for_bytes(self, content: bytes) -> "Digest":
+        hasher = self.hasher()
+        hasher.update(content)
+        return Digest(f"{self.value}:{hasher.hexdigest()}")
+
     def digest_for_path(self, path: str) -> "Digest":
         hasher = self.hasher()
         with open(path, "rb") as file:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -505,10 +505,10 @@ class Registry:
         digest_obj = oras.oci.Digest(digest)
         hasher = digest_obj.algorithm.hasher()
         blob_size = 0
-        staged = oras.utils.get_tmpfile()
+        outdir = os.path.dirname(outfile)
+        staged = oras.utils.get_tmpfile(tmpdir=outdir)
         try:
             # Ensure output directory exists first
-            outdir = os.path.dirname(outfile)
             if outdir and not os.path.exists(outdir):
                 oras.utils.mkdir_p(outdir)
             with self.get_blob(container, digest, stream=True) as r:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -3,18 +3,14 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import copy
-import enum
-import hashlib
-import hmac
 import os
-import re
 import sys
 import urllib
 from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
 from http.cookiejar import DefaultCookiePolicy
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Generator, List, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple, Union
 
 import jsonschema
 import requests
@@ -30,87 +26,6 @@ import oras.utils
 from oras.logger import logger
 from oras.types import container_type
 from oras.utils.fileio import PathAndOptionalContent
-
-_DIGEST_PATTERN = re.compile(
-    r"^(?P<algorithm>[a-z0-9]+(?:[+._-][a-z0-9]+)*):" r"(?P<encoded>[a-zA-Z0-9=_-]+)$"
-)
-
-
-class RegisteredDigestAlgorithm(str, enum.Enum):
-    SHA256 = "sha256"
-    SHA512 = "sha512"
-
-    def hasher(self) -> Any:
-        try:
-            return hashlib.new(self.value)
-        except ValueError as error:
-            raise ValueError(f"Unsupported OCI digest algorithm: {self}.") from error
-
-
-def _parse_digest(digest: str) -> Tuple[RegisteredDigestAlgorithm, str]:
-    """Parse and validate an OCI digest's algorithm and encoded value."""
-    if not isinstance(digest, str):
-        raise ValueError(f"Invalid OCI digest: {digest!r}.")
-
-    match = _DIGEST_PATTERN.fullmatch(digest)
-    if not match:
-        raise ValueError(f"Invalid OCI digest: {digest!r}.")
-
-    algorithm = match.group("algorithm")
-    try:
-        registered_algorithm = RegisteredDigestAlgorithm(algorithm)
-    except ValueError as error:
-        raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.") from error
-    encoded = match.group("encoded")
-    encoded_length = registered_algorithm.hasher().digest_size * 2
-    if encoded_length is None:
-        raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.")
-
-    if not re.fullmatch(f"[a-f0-9]{{{encoded_length}}}", encoded):
-        raise ValueError(
-            f"Invalid {algorithm} digest encoding: expected {encoded_length} "
-            "lowercase hexadecimal characters."
-        )
-
-    return registered_algorithm, encoded
-
-
-class Digest:
-    def __init__(self, digest: str) -> None:
-        self.algorithm, self.encoded = _parse_digest(digest)
-
-    @property
-    def digest(self) -> str:
-        return f"{self.algorithm.value}:{self.encoded}"
-
-    def __str__(self) -> str:
-        return self.digest
-
-
-def _validate_downloaded_blob(
-    path: str,
-    digest: Digest,
-    expected_size: int,
-) -> None:
-    """Validate a downloaded blob's descriptor size and digest."""
-    actual_size = os.path.getsize(path)
-    if actual_size != expected_size:
-        raise ValueError(
-            f"Downloaded blob size mismatch for {digest}: expected "
-            f"{expected_size} bytes, got {actual_size} bytes."
-        )
-
-    hasher = digest.algorithm.hasher()
-    with open(path, "rb") as blob:
-        for chunk in iter(lambda: blob.read(8192), b""):
-            hasher.update(chunk)
-
-    actual_encoded = hasher.hexdigest()
-    if not hmac.compare_digest(actual_encoded, digest.encoded):
-        raise ValueError(
-            f"Downloaded blob digest mismatch: expected {digest}, got "
-            f"{digest.algorithm.value}:{actual_encoded}."
-        )
 
 
 @contextmanager
@@ -570,9 +485,35 @@ class Registry:
         )
         return self.upload_blob(blob, container, layer, do_chunked)
 
+    @staticmethod
+    def _validate_blob(
+        path: str,
+        digest: oras.oci.Digest,
+        size: Optional[int] = None,
+    ) -> None:
+        """Validate a downloaded blob's digest and optionally size."""
+        if size is not None:
+            actual_size = os.path.getsize(path)
+            if actual_size != size:
+                raise ValueError(
+                    f"Downloaded blob size mismatch for {digest}: expected "
+                    f"{size} bytes, got {actual_size} bytes."
+                )
+
+        actual_digest = digest.algorithm.hash_path(path)
+        if digest != actual_digest:
+            raise ValueError(
+                f"Downloaded blob digest mismatch: expected {digest!s}, got "
+                f"{actual_digest!s}."
+            )
+
     @decorator.ensure_container
     def download_blob(
-        self, container: container_type, digest: str, outfile: str
+        self,
+        container: container_type,
+        digest: str,
+        outfile: str,
+        size: Optional[int] = None,
     ) -> str:
         """
         Stream download a blob into an output file.
@@ -599,6 +540,7 @@ class Registry:
             if digest == oras.defaults.blank_hash:
                 return os.devnull
             raise e
+        self._validate_blob(outfile, oras.oci.Digest(digest), size)
         return outfile
 
     def put_upload(
@@ -1002,16 +944,10 @@ class Registry:
                 )
                 continue
 
-            digest = Digest(layer["digest"])
-            expected_size = layer["size"]
-            if (
-                not isinstance(expected_size, int)
-                or isinstance(expected_size, bool)
-                or expected_size < 0
-            ):
-                raise ValueError(
-                    f"Invalid OCI descriptor size for {digest.digest}: {expected_size!r}."
-                )
+            digest = layer["digest"]
+            size = layer["size"]
+            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                raise ValueError(f"Invalid OCI descriptor size for {digest}: {size!r}.")
 
             outfile_dir = os.path.dirname(outfile)
             if outfile_dir and not os.path.exists(outfile_dir):
@@ -1023,12 +959,7 @@ class Registry:
                     layer["mediaType"] == oras.defaults.default_blob_dir_media_type
                 )
                 staged = os.path.join(tmpdir, "blob.tar.gz" if is_directory else "blob")
-                self.download_blob(container, digest.digest, staged)
-                _validate_downloaded_blob(
-                    staged,
-                    digest,
-                    expected_size,
-                )
+                self.download_blob(container, digest, staged, size)
 
                 # A verified directory archive can now be safely consumed.
                 if is_directory:

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -1003,7 +1003,7 @@ class Registry:
         expected_digest: Optional[str] = None,
         expected_size: Optional[int] = None,
     ) -> Tuple[requests.Response, oras.oci.Digest]:
-        """Fetch and verify a manifest before it is parsed or consumed."""
+        """Fetch a manifest and verify all available integrity assertions."""
         # Load authentication configs for the container's registry. This also makes
         # the helper safe for callers such as the OCI-layout implementation.
         self.auth.load_configs(container)
@@ -1025,17 +1025,17 @@ class Registry:
 
         requested_digest = oras.oci.Digest(expected_digest) if expected_digest else None
         header_value = response.headers.get("Docker-Content-Digest")
-        if not header_value:
-            raise ValueError("Expected to find Docker-Content-Digest header.")
-
-        header_digest = oras.oci.Digest(header_value)
-        # Verify that the digest in the header matches what we received.
-        actual = header_digest.algorithm.digest_for_bytes(content)
-        if header_digest != actual:
-            raise ValueError(
-                f"Downloaded manifest digest mismatch: expected {header_digest!s}, "
-                f"got {actual!s}."
-            )
+        header_digest = (
+            oras.oci.Digest(header_value) if header_value is not None else None
+        )
+        if header_digest:
+            # A supplied canonical digest must match the received manifest.
+            actual = header_digest.algorithm.digest_for_bytes(content)
+            if header_digest != actual:
+                raise ValueError(
+                    f"Downloaded manifest digest mismatch: expected {header_digest!s}, "
+                    f"got {actual!s}."
+                )
 
         # Verify that the data we've received matches what we asked for.
         if requested_digest:
@@ -1046,8 +1046,14 @@ class Registry:
                     f"got {actual!s}."
                 )
 
-        # Prefer the requested digest and fallback to the registry's canonical digest.
-        return response, requested_digest or header_digest
+        # Preserve an addressing digest when one was supplied. For a headerless tag,
+        # calculate a stable local content address from the raw response bytes.
+        manifest_digest = (
+            requested_digest
+            or header_digest
+            or oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(content)
+        )
+        return response, manifest_digest
 
     @decorator.retry()
     def do_request(

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -540,7 +540,13 @@ class Registry:
             if digest == oras.defaults.blank_hash:
                 return os.devnull
             raise e
-        self._validate_blob(outfile, oras.oci.Digest(digest), size)
+
+        try:
+            self._validate_blob(outfile, oras.oci.Digest(digest), size)
+        except Exception:
+            os.remove(outfile)
+            raise
+
         return outfile
 
     def put_upload(
@@ -916,7 +922,6 @@ class Registry:
         :type outdir: str
         :param target: target location to pull from
         :type target: str
-        :raises ValueError: if a layer descriptor or downloaded layer is invalid
         """
         container = self.get_container(target)
         self.auth.load_configs(
@@ -944,29 +949,17 @@ class Registry:
                 )
                 continue
 
-            digest = layer["digest"]
-            size = layer["size"]
-            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
-                raise ValueError(f"Invalid OCI descriptor size for {digest}: {size!r}.")
+            # A directory will need to be uncompressed and moved
+            if layer["mediaType"] == oras.defaults.default_blob_dir_media_type:
+                targz = oras.utils.get_tmpfile(suffix=".tar.gz")
+                self.download_blob(container, layer["digest"], targz, layer["size"])
 
-            outfile_dir = os.path.dirname(outfile)
-            if outfile_dir and not os.path.exists(outfile_dir):
-                oras.utils.mkdir_p(outfile_dir)
+                # The artifact will be extracted to the correct name
+                oras.utils.extract_targz(targz, os.path.dirname(outfile))
 
-            # Keep downloaded content private until its descriptor is verified.
-            with TemporaryDirectory(prefix=".oras-", dir=outfile_dir) as tmpdir:
-                is_directory = (
-                    layer["mediaType"] == oras.defaults.default_blob_dir_media_type
-                )
-                staged = os.path.join(tmpdir, "blob.tar.gz" if is_directory else "blob")
-                self.download_blob(container, digest, staged, size)
-
-                # A verified directory archive can now be safely consumed.
-                if is_directory:
-                    oras.utils.extract_targz(staged, outfile_dir)
-                else:
-                    os.replace(staged, outfile)
-
+            # Anything else just extracted directly
+            else:
+                self.download_blob(container, layer["digest"], outfile, layer["size"])
             logger.info(f"Successfully pulled {outfile}.")
             files.append(outfile)
         return files

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import copy
+import json
 import os
 import sys
 import urllib
@@ -979,24 +980,24 @@ class Registry:
         :param validation_schema: optional json schema to validate the manifest against
         :type validation_schema: dict
         """
-        response, _ = self._get_manifest_response(
+        manifest_bytes, _ = self._get_manifest_bytes(
             container,
             allowed_media_type=allowed_media_type,
             expected_digest=container.digest,  # type: ignore
         )
-        manifest = response.json()
+        manifest = json.loads(manifest_bytes)
         if validation_schema:
             jsonschema.validate(manifest, schema=validation_schema)
         return manifest
 
-    def _get_manifest_response(
+    def _get_manifest_bytes(
         self,
         container: oras.container.Container,
         allowed_media_type: Optional[list] = None,
         reference: Optional[str] = None,
         expected_digest: Optional[str] = None,
         expected_size: Optional[int] = None,
-    ) -> Tuple[requests.Response, oras.oci.Digest]:
+    ) -> Tuple[bytes, oras.oci.Digest]:
         """Fetch a manifest and verify all available integrity assertions."""
         # Load authentication configs for the container's registry. This also makes
         # the helper safe for callers such as the OCI-layout implementation.
@@ -1010,11 +1011,11 @@ class Registry:
         response = self.do_request(get_manifest, "GET", headers=headers)
         self._check_200_response(response)
 
-        content = response.content
-        if expected_size is not None and len(content) != expected_size:
+        manifest_bytes = response.content
+        if expected_size is not None and len(manifest_bytes) != expected_size:
             raise ValueError(
                 "Downloaded manifest size mismatch: expected "
-                f"{expected_size} bytes, got {len(content)} bytes."
+                f"{expected_size} bytes, got {len(manifest_bytes)} bytes."
             )
 
         requested_digest = oras.oci.Digest(expected_digest) if expected_digest else None
@@ -1024,7 +1025,7 @@ class Registry:
         )
         if header_digest:
             # A supplied canonical digest must match the received manifest.
-            actual = header_digest.algorithm.digest_for_bytes(content)
+            actual = header_digest.algorithm.digest_for_bytes(manifest_bytes)
             if header_digest != actual:
                 raise ValueError(
                     f"Downloaded manifest digest mismatch: expected {header_digest!s}, "
@@ -1033,7 +1034,7 @@ class Registry:
 
         # Verify that the data we've received matches what we asked for.
         if requested_digest:
-            actual = requested_digest.algorithm.digest_for_bytes(content)
+            actual = requested_digest.algorithm.digest_for_bytes(manifest_bytes)
             if requested_digest != actual:
                 raise ValueError(
                     f"Downloaded manifest digest mismatch: expected {requested_digest!s}, "
@@ -1045,9 +1046,11 @@ class Registry:
         manifest_digest = (
             requested_digest
             or header_digest
-            or oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(content)
+            or oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+                manifest_bytes
+            )
         )
-        return response, manifest_digest
+        return manifest_bytes, manifest_digest
 
     @decorator.retry()
     def do_request(

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -485,28 +485,6 @@ class Registry:
         )
         return self.upload_blob(blob, container, layer, do_chunked)
 
-    @staticmethod
-    def _validate_blob(
-        path: str,
-        digest: oras.oci.Digest,
-        size: Optional[int] = None,
-    ) -> None:
-        """Validate a downloaded blob's digest and optionally size."""
-        if size is not None:
-            actual_size = os.path.getsize(path)
-            if actual_size != size:
-                raise ValueError(
-                    f"Downloaded blob size mismatch for {digest}: expected "
-                    f"{size} bytes, got {actual_size} bytes."
-                )
-
-        actual_digest = digest.algorithm.digest_for_path(path)
-        if digest != actual_digest:
-            raise ValueError(
-                f"Downloaded blob digest mismatch: expected {digest!s}, got "
-                f"{actual_digest!s}."
-            )
-
     @decorator.ensure_container
     def download_blob(
         self,
@@ -523,6 +501,10 @@ class Registry:
         :param container:  parsed container URI
         :type container: oras.container.Container or str
         """
+        digest_obj = oras.oci.Digest(digest)
+        hasher = digest_obj.algorithm.hasher()
+        blob_size = 0
+        staged = oras.utils.get_tmpfile()
         try:
             # Ensure output directory exists first
             outdir = os.path.dirname(outfile)
@@ -530,22 +512,44 @@ class Registry:
                 oras.utils.mkdir_p(outdir)
             with self.get_blob(container, digest, stream=True) as r:
                 r.raise_for_status()
-                with open(outfile, "wb") as f:
+                with open(staged, "wb") as f:
                     for chunk in r.iter_content(chunk_size=8192):
                         if chunk:
+                            blob_size += len(chunk)
+                            if size is not None and blob_size > size:
+                                raise ValueError(
+                                    "Downloaded blob size larger than expected."
+                                )
+                            hasher.update(chunk)
                             f.write(chunk)
+
+            blob_digest = oras.oci.Digest(
+                f"{digest_obj.algorithm.value}:{hasher.hexdigest()}"
+            )
+            if size is not None and size != blob_size:
+                raise ValueError(
+                    f"Downloaded blob size mismatch for {digest}: expected "
+                    f"{size} bytes, got {blob_size} bytes."
+                )
+
+            if digest_obj != blob_digest:
+                raise ValueError(
+                    f"Downloaded blob digest mismatch: expected {digest!s}, got "
+                    f"{blob_digest!s}."
+                )
+
+            os.replace(staged, outfile)
 
         # Allow an empty layer to fail and return /dev/null
         except Exception as e:
             if digest == oras.defaults.blank_hash:
                 return os.devnull
             raise e
-
-        try:
-            self._validate_blob(outfile, oras.oci.Digest(digest), size)
-        except Exception:
-            os.remove(outfile)
-            raise
+        finally:
+            try:
+                os.remove(staged)
+            except FileNotFoundError:
+                pass
 
         return outfile
 

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -539,12 +539,6 @@ class Registry:
                 )
 
             os.replace(staged, outfile)
-
-        # Allow an empty layer to fail and return /dev/null
-        except Exception as e:
-            if digest == oras.defaults.blank_hash:
-                return os.devnull
-            raise e
         finally:
             try:
                 os.remove(staged)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -500,7 +500,7 @@ class Registry:
                     f"{size} bytes, got {actual_size} bytes."
                 )
 
-        actual_digest = digest.algorithm.hash_path(path)
+        actual_digest = digest.algorithm.digest_for_path(path)
         if digest != actual_digest:
             raise ValueError(
                 f"Downloaded blob digest mismatch: expected {digest!s}, got "

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -985,22 +985,69 @@ class Registry:
         :param validation_schema: optional json schema to validate the manifest against
         :type validation_schema: dict
         """
-        # Load authentication configs for the container's registry
-        # This ensures credentials are available for authenticated registries
+        response, _ = self._get_manifest_response(
+            container,
+            allowed_media_type=allowed_media_type,
+            expected_digest=container.digest,  # type: ignore
+        )
+        manifest = response.json()
+        if validation_schema:
+            jsonschema.validate(manifest, schema=validation_schema)
+        return manifest
+
+    def _get_manifest_response(
+        self,
+        container: oras.container.Container,
+        allowed_media_type: Optional[list] = None,
+        reference: Optional[str] = None,
+        expected_digest: Optional[str] = None,
+        expected_size: Optional[int] = None,
+    ) -> Tuple[requests.Response, oras.oci.Digest]:
+        """Fetch and verify a manifest before it is parsed or consumed."""
+        # Load authentication configs for the container's registry. This also makes
+        # the helper safe for callers such as the OCI-layout implementation.
         self.auth.load_configs(container)
 
         if not allowed_media_type:
             allowed_media_type = oras.defaults.default_manifest_accepted_media_types
         headers = {"Accept": ", ".join(allowed_media_type)}
 
-        get_manifest = f"{self.prefix}://{container.manifest_url()}"  # type: ignore
+        get_manifest = f"{self.prefix}://{container.manifest_url(reference)}"
         response = self.do_request(get_manifest, "GET", headers=headers)
-
         self._check_200_response(response)
-        manifest = response.json()
-        if validation_schema:
-            jsonschema.validate(manifest, schema=validation_schema)
-        return manifest
+
+        content = response.content
+        if expected_size is not None and len(content) != expected_size:
+            raise ValueError(
+                "Downloaded manifest size mismatch: expected "
+                f"{expected_size} bytes, got {len(content)} bytes."
+            )
+
+        requested_digest = oras.oci.Digest(expected_digest) if expected_digest else None
+        header_value = response.headers.get("Docker-Content-Digest")
+        if not header_value:
+            raise ValueError("Expected to find Docker-Content-Digest header.")
+
+        header_digest = oras.oci.Digest(header_value)
+        # Verify that the digest in the header matches what we received.
+        actual = header_digest.algorithm.digest_for_bytes(content)
+        if header_digest != actual:
+            raise ValueError(
+                f"Downloaded manifest digest mismatch: expected {header_digest!s}, "
+                f"got {actual!s}."
+            )
+
+        # Verify that the data we've received matches what we asked for.
+        if requested_digest:
+            actual = requested_digest.algorithm.digest_for_bytes(content)
+            if requested_digest != actual:
+                raise ValueError(
+                    f"Downloaded manifest digest mismatch: expected {requested_digest!s}, "
+                    f"got {actual!s}."
+                )
+
+        # Prefer the requested digest and fallback to the registry's canonical digest.
+        return response, requested_digest or header_digest
 
     @decorator.retry()
     def do_request(

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -3,14 +3,18 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import copy
+import enum
+import hashlib
+import hmac
 import os
+import re
 import sys
 import urllib
 from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
 from http.cookiejar import DefaultCookiePolicy
 from tempfile import TemporaryDirectory
-from typing import Callable, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Generator, List, Optional, Tuple, Union
 
 import jsonschema
 import requests
@@ -26,6 +30,87 @@ import oras.utils
 from oras.logger import logger
 from oras.types import container_type
 from oras.utils.fileio import PathAndOptionalContent
+
+_DIGEST_PATTERN = re.compile(
+    r"^(?P<algorithm>[a-z0-9]+(?:[+._-][a-z0-9]+)*):" r"(?P<encoded>[a-zA-Z0-9=_-]+)$"
+)
+
+
+class RegisteredDigestAlgorithm(str, enum.Enum):
+    SHA256 = "sha256"
+    SHA512 = "sha512"
+
+    def hasher(self) -> Any:
+        try:
+            return hashlib.new(self.value)
+        except ValueError as error:
+            raise ValueError(f"Unsupported OCI digest algorithm: {self}.") from error
+
+
+def _parse_digest(digest: str) -> Tuple[RegisteredDigestAlgorithm, str]:
+    """Parse and validate an OCI digest's algorithm and encoded value."""
+    if not isinstance(digest, str):
+        raise ValueError(f"Invalid OCI digest: {digest!r}.")
+
+    match = _DIGEST_PATTERN.fullmatch(digest)
+    if not match:
+        raise ValueError(f"Invalid OCI digest: {digest!r}.")
+
+    algorithm = match.group("algorithm")
+    try:
+        registered_algorithm = RegisteredDigestAlgorithm(algorithm)
+    except ValueError as error:
+        raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.") from error
+    encoded = match.group("encoded")
+    encoded_length = registered_algorithm.hasher().digest_size * 2
+    if encoded_length is None:
+        raise ValueError(f"Unsupported OCI digest algorithm: {algorithm}.")
+
+    if not re.fullmatch(f"[a-f0-9]{{{encoded_length}}}", encoded):
+        raise ValueError(
+            f"Invalid {algorithm} digest encoding: expected {encoded_length} "
+            "lowercase hexadecimal characters."
+        )
+
+    return registered_algorithm, encoded
+
+
+class Digest:
+    def __init__(self, digest: str) -> None:
+        self.algorithm, self.encoded = _parse_digest(digest)
+
+    @property
+    def digest(self) -> str:
+        return f"{self.algorithm.value}:{self.encoded}"
+
+    def __str__(self) -> str:
+        return self.digest
+
+
+def _validate_downloaded_blob(
+    path: str,
+    digest: Digest,
+    expected_size: int,
+) -> None:
+    """Validate a downloaded blob's descriptor size and digest."""
+    actual_size = os.path.getsize(path)
+    if actual_size != expected_size:
+        raise ValueError(
+            f"Downloaded blob size mismatch for {digest}: expected "
+            f"{expected_size} bytes, got {actual_size} bytes."
+        )
+
+    hasher = digest.algorithm.hasher()
+    with open(path, "rb") as blob:
+        for chunk in iter(lambda: blob.read(8192), b""):
+            hasher.update(chunk)
+
+    actual_encoded = hasher.hexdigest()
+    if not hmac.compare_digest(actual_encoded, digest.encoded):
+        raise ValueError(
+            f"Downloaded blob digest mismatch: expected {digest}, got "
+            f"{digest.algorithm.value}:{actual_encoded}."
+        )
 
 
 @contextmanager
@@ -889,6 +974,7 @@ class Registry:
         :type outdir: str
         :param target: target location to pull from
         :type target: str
+        :raises ValueError: if a layer descriptor or downloaded layer is invalid
         """
         container = self.get_container(target)
         self.auth.load_configs(
@@ -896,7 +982,6 @@ class Registry:
         )
         manifest = self.get_manifest(container, allowed_media_type)
         outdir = outdir or oras.utils.get_tmpdir()
-        overwrite = overwrite
 
         files = []
         for layer in manifest.get("layers", []):
@@ -917,17 +1002,40 @@ class Registry:
                 )
                 continue
 
-            # A directory will need to be uncompressed and moved
-            if layer["mediaType"] == oras.defaults.default_blob_dir_media_type:
-                targz = oras.utils.get_tmpfile(suffix=".tar.gz")
-                self.download_blob(container, layer["digest"], targz)
+            digest = Digest(layer["digest"])
+            expected_size = layer["size"]
+            if (
+                not isinstance(expected_size, int)
+                or isinstance(expected_size, bool)
+                or expected_size < 0
+            ):
+                raise ValueError(
+                    f"Invalid OCI descriptor size for {digest.digest}: {expected_size!r}."
+                )
 
-                # The artifact will be extracted to the correct name
-                oras.utils.extract_targz(targz, os.path.dirname(outfile))
+            outfile_dir = os.path.dirname(outfile)
+            if outfile_dir and not os.path.exists(outfile_dir):
+                oras.utils.mkdir_p(outfile_dir)
 
-            # Anything else just extracted directly
-            else:
-                self.download_blob(container, layer["digest"], outfile)
+            # Keep downloaded content private until its descriptor is verified.
+            with TemporaryDirectory(prefix=".oras-", dir=outfile_dir) as tmpdir:
+                is_directory = (
+                    layer["mediaType"] == oras.defaults.default_blob_dir_media_type
+                )
+                staged = os.path.join(tmpdir, "blob.tar.gz" if is_directory else "blob")
+                self.download_blob(container, digest.digest, staged)
+                _validate_downloaded_blob(
+                    staged,
+                    digest,
+                    expected_size,
+                )
+
+                # A verified directory archive can now be safely consumed.
+                if is_directory:
+                    oras.utils.extract_targz(staged, outfile_dir)
+                else:
+                    os.replace(staged, outfile)
+
             logger.info(f"Successfully pulled {outfile}.")
             files.append(outfile)
         return files

--- a/oras/tests/test_layout.py
+++ b/oras/tests/test_layout.py
@@ -66,26 +66,6 @@ def make_layout_provider(monkeypatch, responses):
     return provider
 
 
-def test_pull_layout_rejects_top_level_manifest_digest_mismatch(monkeypatch, tmp_path):
-    content = manifest_bytes()
-    wrong_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
-        b"different manifest",
-    ).digest
-    provider = make_layout_provider(
-        monkeypatch, [manifest_response(content, wrong_digest)]
-    )
-    layout_dir = tmp_path / "layout"
-
-    with pytest.raises(ValueError, match="Downloaded manifest digest mismatch"):
-        Layout(str(layout_dir), validate=False).pull_from_registry(
-            provider, "registry.example/repository:tag"
-        )
-
-    assert not (layout_dir / "oci-layout").exists()
-    assert not (layout_dir / "index.json").exists()
-    assert not Layout(str(layout_dir), validate=False).blob_exists(wrong_digest)
-
-
 def test_pull_layout_addresses_headerless_tag_by_sha256(monkeypatch, tmp_path):
     content = manifest_bytes()
     provider = make_layout_provider(monkeypatch, [manifest_response(content, None)])
@@ -155,34 +135,6 @@ def test_pull_layout_rejects_nested_manifest_size_mismatch(monkeypatch, tmp_path
         Layout(str(tmp_path / "layout"), validate=False).pull_from_registry(
             provider, "registry.example/repository:tag"
         )
-
-
-def test_pull_layout_stores_headerless_nested_manifest_by_descriptor_digest(
-    monkeypatch, tmp_path
-):
-    sub_content = manifest_bytes()
-    sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
-        sub_content
-    ).digest
-    top_content = index_bytes(sub_digest, len(sub_content))
-    top_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
-        top_content
-    ).digest
-    provider = make_layout_provider(
-        monkeypatch,
-        [
-            manifest_response(top_content, top_digest),
-            manifest_response(sub_content, None),
-        ],
-    )
-    layout_dir = tmp_path / "layout"
-
-    layout = Layout(str(layout_dir), validate=False)
-    layout.pull_from_registry(provider, "registry.example/repository:tag")
-
-    assert layout.digest_to_blob_path(sub_digest).read_bytes() == sub_content
-    assert layout.digest_to_blob_path(top_digest).read_bytes() == top_content
-    assert layout.validate()
 
 
 def test_pull_layout_preserves_nested_descriptor_digest(monkeypatch, tmp_path):

--- a/oras/tests/test_layout.py
+++ b/oras/tests/test_layout.py
@@ -2,14 +2,182 @@ __author__ = "Matteo Mortari"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import json
 import pathlib
 
 import pytest
+import requests
 
 import oras.client
+import oras.defaults
+import oras.oci
 import oras.provider
 import oras.utils as utils
 from oras.layout import Layout, NewLayout, NewLayoutFromRegistry
+
+
+def manifest_response(content, digest_header):
+    """Build a successful manifest response with optional digest metadata."""
+    response = requests.Response()
+    response.status_code = 200
+    response._content = content
+    response._content_consumed = True
+    if digest_header is not None:
+        response.headers["Docker-Content-Digest"] = digest_header
+    return response
+
+
+def manifest_bytes():
+    return json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": oras.defaults.default_manifest_media_type,
+            "config": {},
+            "layers": [],
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def index_bytes(sub_digest, sub_size):
+    return json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": oras.defaults.default_index_media_type,
+            "manifests": [
+                {
+                    "mediaType": oras.defaults.default_manifest_media_type,
+                    "digest": sub_digest,
+                    "size": sub_size,
+                }
+            ],
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def make_layout_provider(monkeypatch, responses):
+    provider = oras.provider.Registry(hostname="registry.example", insecure=True)
+    monkeypatch.setattr(provider.auth, "load_configs", lambda *args, **kwargs: None)
+    response_iter = iter(responses)
+    monkeypatch.setattr(
+        provider, "do_request", lambda *args, **kwargs: next(response_iter)
+    )
+    return provider
+
+
+def test_pull_layout_rejects_top_level_manifest_digest_mismatch(monkeypatch, tmp_path):
+    content = manifest_bytes()
+    wrong_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        b"different manifest",
+    ).digest
+    provider = make_layout_provider(
+        monkeypatch, [manifest_response(content, wrong_digest)]
+    )
+    layout_dir = tmp_path / "layout"
+
+    with pytest.raises(ValueError, match="Downloaded manifest digest mismatch"):
+        Layout(str(layout_dir), validate=False).pull_from_registry(
+            provider, "registry.example/repository:tag"
+        )
+
+    assert not (layout_dir / "oci-layout").exists()
+    assert not (layout_dir / "index.json").exists()
+    assert not Layout(str(layout_dir), validate=False).blob_exists(wrong_digest)
+
+
+def test_pull_layout_fails_for_headerless_tag(monkeypatch, tmp_path):
+    content = manifest_bytes()
+    provider = make_layout_provider(monkeypatch, [manifest_response(content, None)])
+    layout_dir = tmp_path / "layout"
+
+    layout = Layout(str(layout_dir), validate=False)
+    with pytest.raises(
+        ValueError, match="Expected to find Docker-Content-Digest header."
+    ):
+        layout.pull_from_registry(provider, "registry.example/repository:tag")
+
+
+def test_pull_layout_rejects_nested_manifest_digest_mismatch(monkeypatch, tmp_path):
+    sub_content = manifest_bytes()
+    correct_sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        sub_content
+    ).digest
+    wrong_sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        b"different sub-manifest"
+    ).digest
+    top_content = index_bytes(wrong_sub_digest, len(sub_content))
+    top_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        top_content,
+    ).digest
+
+    provider = make_layout_provider(
+        monkeypatch,
+        [
+            manifest_response(top_content, top_digest),
+            manifest_response(sub_content, correct_sub_digest),
+        ],
+    )
+    layout_dir = tmp_path / "layout"
+
+    with pytest.raises(ValueError, match="Downloaded manifest digest mismatch"):
+        Layout(str(layout_dir), validate=False).pull_from_registry(
+            provider, "registry.example/repository:tag"
+        )
+
+    layout = Layout(str(layout_dir), validate=False)
+    assert not layout.blob_exists(wrong_sub_digest)
+    assert not layout.blob_exists(top_digest)
+    assert not (layout_dir / "index.json").exists()
+
+
+def test_pull_layout_rejects_nested_manifest_size_mismatch(monkeypatch, tmp_path):
+    sub_content = manifest_bytes()
+    sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        sub_content
+    ).digest
+    top_content = index_bytes(sub_digest, len(sub_content) + 1)
+    top_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        top_content
+    ).digest
+    provider = make_layout_provider(
+        monkeypatch,
+        [
+            manifest_response(top_content, top_digest),
+            manifest_response(sub_content, None),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Downloaded manifest size mismatch"):
+        Layout(str(tmp_path / "layout"), validate=False).pull_from_registry(
+            provider, "registry.example/repository:tag"
+        )
+
+
+def test_pull_layout_stores_verified_nested_manifest_bytes(monkeypatch, tmp_path):
+    sub_content = manifest_bytes()
+    sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        sub_content
+    ).digest
+    top_content = index_bytes(sub_digest, len(sub_content))
+    top_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        top_content
+    ).digest
+    provider = make_layout_provider(
+        monkeypatch,
+        [
+            manifest_response(top_content, top_digest),
+            manifest_response(sub_content, sub_digest),
+        ],
+    )
+    layout_dir = tmp_path / "layout"
+
+    layout = Layout(str(layout_dir), validate=False)
+    layout.pull_from_registry(provider, "registry.example/repository:tag")
+
+    assert layout.digest_to_blob_path(sub_digest).read_bytes() == sub_content
+    assert layout.digest_to_blob_path(top_digest).read_bytes() == top_content
+    assert layout.validate()
 
 
 def test_validate_oci_layout_valid_minimal(tmp_path):

--- a/oras/tests/test_layout.py
+++ b/oras/tests/test_layout.py
@@ -86,16 +86,19 @@ def test_pull_layout_rejects_top_level_manifest_digest_mismatch(monkeypatch, tmp
     assert not Layout(str(layout_dir), validate=False).blob_exists(wrong_digest)
 
 
-def test_pull_layout_fails_for_headerless_tag(monkeypatch, tmp_path):
+def test_pull_layout_addresses_headerless_tag_by_sha256(monkeypatch, tmp_path):
     content = manifest_bytes()
     provider = make_layout_provider(monkeypatch, [manifest_response(content, None)])
     layout_dir = tmp_path / "layout"
+    digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(content).digest
 
     layout = Layout(str(layout_dir), validate=False)
-    with pytest.raises(
-        ValueError, match="Expected to find Docker-Content-Digest header."
-    ):
-        layout.pull_from_registry(provider, "registry.example/repository:tag")
+    layout.pull_from_registry(provider, "registry.example/repository:tag")
+
+    index = json.loads((layout_dir / "index.json").read_bytes())
+    assert index["manifests"][0]["digest"] == digest
+    assert layout.digest_to_blob_path(digest).read_bytes() == content
+    assert layout.validate()
 
 
 def test_pull_layout_rejects_nested_manifest_digest_mismatch(monkeypatch, tmp_path):
@@ -154,7 +157,9 @@ def test_pull_layout_rejects_nested_manifest_size_mismatch(monkeypatch, tmp_path
         )
 
 
-def test_pull_layout_stores_verified_nested_manifest_bytes(monkeypatch, tmp_path):
+def test_pull_layout_stores_headerless_nested_manifest_by_descriptor_digest(
+    monkeypatch, tmp_path
+):
     sub_content = manifest_bytes()
     sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
         sub_content
@@ -167,7 +172,7 @@ def test_pull_layout_stores_verified_nested_manifest_bytes(monkeypatch, tmp_path
         monkeypatch,
         [
             manifest_response(top_content, top_digest),
-            manifest_response(sub_content, sub_digest),
+            manifest_response(sub_content, None),
         ],
     )
     layout_dir = tmp_path / "layout"
@@ -177,6 +182,35 @@ def test_pull_layout_stores_verified_nested_manifest_bytes(monkeypatch, tmp_path
 
     assert layout.digest_to_blob_path(sub_digest).read_bytes() == sub_content
     assert layout.digest_to_blob_path(top_digest).read_bytes() == top_content
+    assert layout.validate()
+
+
+def test_pull_layout_preserves_nested_descriptor_digest(monkeypatch, tmp_path):
+    sub_content = manifest_bytes()
+    sub_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        sub_content
+    ).digest
+    canonical_digest = oras.oci.RegisteredDigestAlgorithm.SHA512.digest_for_bytes(
+        sub_content
+    ).digest
+    top_content = index_bytes(sub_digest, len(sub_content))
+    top_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        top_content
+    ).digest
+    provider = make_layout_provider(
+        monkeypatch,
+        [
+            manifest_response(top_content, top_digest),
+            manifest_response(sub_content, canonical_digest),
+        ],
+    )
+    layout_dir = tmp_path / "layout"
+
+    layout = Layout(str(layout_dir), validate=False)
+    layout.pull_from_registry(provider, "registry.example/repository:tag")
+
+    assert layout.digest_to_blob_path(sub_digest).read_bytes() == sub_content
+    assert not layout.blob_exists(canonical_digest)
     assert layout.validate()
 
 

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import hashlib
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -17,6 +18,11 @@ import oras.provider
 import oras.utils
 
 here = Path(__file__).resolve().parent
+
+MANIFEST_CONTENT = (
+    b'{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",'
+    b'"config":{},"layers":[]}'
+)
 
 
 def make_pull_client(monkeypatch, layer, content):
@@ -41,10 +47,97 @@ def make_pull_client(monkeypatch, layer, content):
     return client
 
 
+def make_manifest_client(monkeypatch, content, digest_header):
+    """Create a registry client with a fixed manifest response."""
+    client = oras.provider.Registry(hostname="registry.example", insecure=True)
+    monkeypatch.setattr(client.auth, "load_configs", lambda *args, **kwargs: None)
+
+    response = requests.Response()
+    response.status_code = 200
+    response._content = content
+    response._content_consumed = True
+    if digest_header is not None:
+        response.headers["Docker-Content-Digest"] = digest_header
+    monkeypatch.setattr(client, "do_request", lambda *args, **kwargs: response)
+    return client
+
+
 def test_digest_string_round_trip():
     original = f"sha256:{hashlib.sha256(b'content').hexdigest()}"
 
     assert str(oras.oci.Digest(original)) == original
+
+
+def test_get_manifest_verifies_digest_header(monkeypatch):
+    digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        MANIFEST_CONTENT
+    )
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, digest.digest)
+
+    manifest = client.get_manifest("registry.example/repository:tag")
+
+    assert manifest == json.loads(MANIFEST_CONTENT)
+
+
+def test_get_manifest_rejects_digest_header_mismatch(monkeypatch):
+    expected_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        b"different content"
+    )
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, expected_digest.digest)
+
+    with pytest.raises(ValueError, match="Downloaded manifest digest mismatch:"):
+        client.get_manifest("registry.example/repository:tag")
+
+
+def test_get_manifest_fails_without_header(monkeypatch):
+    digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        MANIFEST_CONTENT
+    )
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, None)
+
+    with pytest.raises(
+        ValueError, match="Expected to find Docker-Content-Digest header."
+    ):
+        client.get_manifest(f"registry.example/repository@{digest}")
+
+
+def test_get_manifest_rejects_digest_reference_mismatch(monkeypatch):
+    actual_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        MANIFEST_CONTENT
+    ).digest
+    expected_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        b"different content"
+    ).digest
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, actual_digest)
+
+    with pytest.raises(ValueError, match="Downloaded manifest digest mismatch"):
+        client.get_manifest(f"registry.example/repository@{expected_digest}")
+
+
+def test_get_manifest_verifies_reference_and_canonical_header(monkeypatch):
+    requested_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
+        MANIFEST_CONTENT
+    )
+    canonical_digest = oras.oci.RegisteredDigestAlgorithm.SHA512.digest_for_bytes(
+        MANIFEST_CONTENT
+    )
+    client = make_manifest_client(
+        monkeypatch, MANIFEST_CONTENT, canonical_digest.digest
+    )
+
+    manifest = client.get_manifest(f"registry.example/repository@{requested_digest}")
+    assert manifest == json.loads(MANIFEST_CONTENT)
+
+
+@pytest.mark.parametrize(
+    "digest_header",
+    ["sha256:not!hex", f"sha384:{'a' * 96}"],
+)
+def test_get_manifest_rejects_invalid_digest_header(monkeypatch, digest_header):
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, digest_header)
+
+    with pytest.raises(ValueError):
+        client.get_manifest("registry.example/repository:tag")
 
 
 @pytest.mark.parametrize("algorithm", ["sha256", "sha512"])

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -8,10 +8,10 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import requests
 
 import oras.client
 import oras.defaults
-import oras.oci
 import oras.provider
 import oras.utils
 
@@ -29,11 +29,14 @@ def make_pull_client(monkeypatch, layer, content):
         lambda container, allowed_media_type: {"layers": [layer]},
     )
 
-    def download_blob(container, digest, outfile):
-        Path(outfile).write_bytes(content)
-        return outfile
+    def get_blob(container, digest, *args, **kwargs):
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = content
+        resp._content_consumed = True
+        return resp
 
-    monkeypatch.setattr(client, "download_blob", download_blob)
+    monkeypatch.setattr(client, "get_blob", get_blob)
     return client
 
 
@@ -137,7 +140,6 @@ def test_pull_validates_directory_before_extraction(monkeypatch, tmp_path):
     [
         ("sha256+b64u:YWJj", "Unsupported OCI digest algorithm"),
         (f"sha384:{'a' * 96}", "Unsupported OCI digest algorithm"),
-        (f"sha256:{'A' * 64}", "Invalid sha256 digest encoding"),
         (f"sha256:{'a' * 63}", "Invalid sha256 digest encoding"),
         ("sha256:not!hex", "Invalid OCI digest"),
         ("sha256:", "Invalid OCI digest"),

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -163,6 +163,30 @@ def test_pull_validates_registered_digest(monkeypatch, tmp_path, algorithm):
     assert outfile.read_bytes() == content
 
 
+def test_download_blob_validates_empty_blob(monkeypatch, tmp_path):
+    client = oras.provider.Registry(insecure=True)
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b""
+    response._content_consumed = True
+    monkeypatch.setattr(client, "get_blob", lambda *args, **kwargs: response)
+    staged = tmp_path / "staged"
+    staged.touch()
+    monkeypatch.setattr(oras.utils, "get_tmpfile", lambda: str(staged))
+    outfile = tmp_path / "empty"
+
+    result = client.download_blob(
+        "registry.example/repository:tag",
+        oras.defaults.blank_hash,
+        str(outfile),
+        size=0,
+    )
+
+    assert result == str(outfile)
+    assert outfile.read_bytes() == b""
+    assert not staged.exists()
+
+
 def test_pull_rejects_digest_mismatch_without_replacing_file(monkeypatch, tmp_path):
     expected_content = b"expected content"
     downloaded_content = b"corrupt! content"

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -62,10 +62,34 @@ def make_manifest_client(monkeypatch, content, digest_header):
     return client
 
 
-def test_digest_string_round_trip():
-    original = f"sha256:{hashlib.sha256(b'content').hexdigest()}"
+@pytest.mark.parametrize("algorithm", ["sha256", "sha512"])
+def test_digest_string_round_trip(algorithm):
+    original = f"{algorithm}:{hashlib.new(algorithm, b'content').hexdigest()}"
 
     assert str(oras.oci.Digest(original)) == original
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "encoded"),
+    [
+        ("sha256", "A" * 64),
+        ("sha256", "g" * 64),
+        ("sha256", "G" * 64),
+        ("sha256", "_" * 64),
+        ("sha512", "=" * 128),
+    ],
+)
+def test_digest_rejects_non_lowercase_hexadecimal_encoding(algorithm, encoded):
+    expected_length = hashlib.new(algorithm).digest_size * 2
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Invalid {algorithm} digest encoding: expected {expected_length} "
+            "lowercase hexadecimal characters"
+        ),
+    ):
+        oras.oci.Digest(f"{algorithm}:{encoded}")
 
 
 def test_get_manifest_verifies_digest_header(monkeypatch):
@@ -172,7 +196,7 @@ def test_download_blob_validates_empty_blob(monkeypatch, tmp_path):
     monkeypatch.setattr(client, "get_blob", lambda *args, **kwargs: response)
     staged = tmp_path / "staged"
     staged.touch()
-    monkeypatch.setattr(oras.utils, "get_tmpfile", lambda: str(staged))
+    monkeypatch.setattr(oras.utils, "get_tmpfile", lambda **kwargs: str(staged))
     outfile = tmp_path / "empty"
 
     result = client.download_blob(
@@ -263,6 +287,7 @@ def test_pull_validates_directory_before_extraction(monkeypatch, tmp_path):
         ("sha256+b64u:YWJj", "Unsupported OCI digest algorithm"),
         (f"sha384:{'a' * 96}", "Unsupported OCI digest algorithm"),
         (f"sha256:{'a' * 63}", "Invalid sha256 digest encoding"),
+        (f"sha256:{'G' * 64}", "Invalid sha256 digest encoding"),
         ("sha256:not!hex", "Invalid OCI digest"),
         ("sha256:", "Invalid OCI digest"),
         (f"SHA256:{'a' * 64}", "Invalid OCI digest"),

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -89,26 +89,30 @@ def test_get_manifest_rejects_digest_header_mismatch(monkeypatch):
         client.get_manifest("registry.example/repository:tag")
 
 
-def test_get_manifest_fails_without_header(monkeypatch):
+def test_get_manifest_verifies_digest_reference_without_header(monkeypatch):
     digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
         MANIFEST_CONTENT
     )
     client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, None)
 
-    with pytest.raises(
-        ValueError, match="Expected to find Docker-Content-Digest header."
-    ):
-        client.get_manifest(f"registry.example/repository@{digest}")
+    manifest = client.get_manifest(f"registry.example/repository@{digest}")
+
+    assert manifest == json.loads(MANIFEST_CONTENT)
+
+
+def test_get_manifest_allows_headerless_tag(monkeypatch):
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, None)
+
+    manifest = client.get_manifest("registry.example/repository:tag")
+
+    assert manifest == json.loads(MANIFEST_CONTENT)
 
 
 def test_get_manifest_rejects_digest_reference_mismatch(monkeypatch):
-    actual_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
-        MANIFEST_CONTENT
-    ).digest
     expected_digest = oras.oci.RegisteredDigestAlgorithm.SHA256.digest_for_bytes(
         b"different content"
     ).digest
-    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, actual_digest)
+    client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, None)
 
     with pytest.raises(ValueError, match="Downloaded manifest digest mismatch"):
         client.get_manifest(f"registry.example/repository@{expected_digest}")
@@ -131,7 +135,7 @@ def test_get_manifest_verifies_reference_and_canonical_header(monkeypatch):
 
 @pytest.mark.parametrize(
     "digest_header",
-    ["sha256:not!hex", f"sha384:{'a' * 96}"],
+    ["", "sha256:not!hex", f"sha384:{'a' * 96}"],
 )
 def test_get_manifest_rejects_invalid_digest_header(monkeypatch, digest_header):
     client = make_manifest_client(monkeypatch, MANIFEST_CONTENT, digest_header)

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -12,6 +12,7 @@ import requests
 
 import oras.client
 import oras.defaults
+import oras.oci
 import oras.provider
 import oras.utils
 
@@ -43,7 +44,7 @@ def make_pull_client(monkeypatch, layer, content):
 def test_digest_string_round_trip():
     original = f"sha256:{hashlib.sha256(b'content').hexdigest()}"
 
-    assert str(oras.provider.Digest(original)) == original
+    assert str(oras.oci.Digest(original)) == original
 
 
 @pytest.mark.parametrize("algorithm", ["sha256", "sha512"])

--- a/oras/tests/test_provider.py
+++ b/oras/tests/test_provider.py
@@ -2,6 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import hashlib
 import os
 import subprocess
 from pathlib import Path
@@ -15,6 +16,147 @@ import oras.provider
 import oras.utils
 
 here = Path(__file__).resolve().parent
+
+
+def make_pull_client(monkeypatch, layer, content):
+    """Create a registry client whose pull inputs do not require a live registry."""
+    client = oras.provider.Registry(insecure=True)
+    monkeypatch.setattr(client, "get_container", lambda target: target)
+    monkeypatch.setattr(client.auth, "load_configs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        client,
+        "get_manifest",
+        lambda container, allowed_media_type: {"layers": [layer]},
+    )
+
+    def download_blob(container, digest, outfile):
+        Path(outfile).write_bytes(content)
+        return outfile
+
+    monkeypatch.setattr(client, "download_blob", download_blob)
+    return client
+
+
+def test_digest_string_round_trip():
+    original = f"sha256:{hashlib.sha256(b'content').hexdigest()}"
+
+    assert str(oras.provider.Digest(original)) == original
+
+
+@pytest.mark.parametrize("algorithm", ["sha256", "sha512"])
+def test_pull_validates_registered_digest(monkeypatch, tmp_path, algorithm):
+    content = b"verified content"
+    digest = f"{algorithm}:{hashlib.new(algorithm, content).hexdigest()}"
+    layer = {
+        "mediaType": oras.defaults.default_blob_media_type,
+        "size": len(content),
+        "digest": digest,
+        "annotations": {oras.defaults.annotation_title: "artifact.txt"},
+    }
+    client = make_pull_client(monkeypatch, layer, content)
+
+    files = client.pull("registry.example/repository:tag", outdir=str(tmp_path))
+
+    outfile = tmp_path / "artifact.txt"
+    assert files == [str(outfile)]
+    assert outfile.read_bytes() == content
+
+
+def test_pull_rejects_digest_mismatch_without_replacing_file(monkeypatch, tmp_path):
+    expected_content = b"expected content"
+    downloaded_content = b"corrupt! content"
+    digest = f"sha256:{hashlib.sha256(expected_content).hexdigest()}"
+    layer = {
+        "mediaType": oras.defaults.default_blob_media_type,
+        "size": len(downloaded_content),
+        "digest": digest,
+        "annotations": {oras.defaults.annotation_title: "artifact.txt"},
+    }
+    client = make_pull_client(monkeypatch, layer, downloaded_content)
+    outfile = tmp_path / "artifact.txt"
+    outfile.write_bytes(b"existing content")
+
+    with pytest.raises(ValueError) as error:
+        client.pull("registry.example/repository:tag", outdir=str(tmp_path))
+
+    actual_digest = f"sha256:{hashlib.sha256(downloaded_content).hexdigest()}"
+    assert str(error.value) == (
+        f"Downloaded blob digest mismatch: expected {digest}, got {actual_digest}."
+    )
+    assert outfile.read_bytes() == b"existing content"
+    assert not list(tmp_path.glob(".oras-*"))
+
+
+def test_pull_rejects_size_mismatch(monkeypatch, tmp_path):
+    content = b"content"
+    digest = f"sha256:{hashlib.sha256(content).hexdigest()}"
+    layer = {
+        "mediaType": oras.defaults.default_blob_media_type,
+        "size": len(content) + 1,
+        "digest": digest,
+        "annotations": {oras.defaults.annotation_title: "artifact.txt"},
+    }
+    client = make_pull_client(monkeypatch, layer, content)
+
+    with pytest.raises(ValueError, match="Downloaded blob size mismatch"):
+        client.pull("registry.example/repository:tag", outdir=str(tmp_path))
+
+    assert not (tmp_path / "artifact.txt").exists()
+    assert not list(tmp_path.glob(".oras-*"))
+
+
+def test_pull_validates_directory_before_extraction(monkeypatch, tmp_path):
+    expected_content = b"expected archive"
+    downloaded_content = b"corrupted archive"
+    digest = f"sha256:{hashlib.sha256(expected_content).hexdigest()}"
+    layer = {
+        "mediaType": oras.defaults.default_blob_dir_media_type,
+        "size": len(downloaded_content),
+        "digest": digest,
+        "annotations": {oras.defaults.annotation_title: "artifact"},
+    }
+    client = make_pull_client(monkeypatch, layer, downloaded_content)
+    extracted = False
+
+    def extract_targz(*args, **kwargs):
+        nonlocal extracted
+        extracted = True
+
+    monkeypatch.setattr(oras.utils, "extract_targz", extract_targz)
+
+    with pytest.raises(ValueError, match="Downloaded blob digest mismatch"):
+        client.pull("registry.example/repository:tag", outdir=str(tmp_path))
+
+    assert not extracted
+    assert not (tmp_path / "artifact").exists()
+    assert not list(tmp_path.glob(".oras-*"))
+
+
+@pytest.mark.parametrize(
+    ("digest", "error"),
+    [
+        ("sha256+b64u:YWJj", "Unsupported OCI digest algorithm"),
+        (f"sha384:{'a' * 96}", "Unsupported OCI digest algorithm"),
+        (f"sha256:{'A' * 64}", "Invalid sha256 digest encoding"),
+        (f"sha256:{'a' * 63}", "Invalid sha256 digest encoding"),
+        ("sha256:not!hex", "Invalid OCI digest"),
+        ("sha256:", "Invalid OCI digest"),
+        (f"SHA256:{'a' * 64}", "Invalid OCI digest"),
+    ],
+)
+def test_pull_rejects_invalid_digest_encoding(monkeypatch, tmp_path, digest, error):
+    layer = {
+        "mediaType": oras.defaults.default_blob_media_type,
+        "size": 0,
+        "digest": digest,
+        "annotations": {oras.defaults.annotation_title: "artifact.txt"},
+    }
+    client = make_pull_client(monkeypatch, layer, b"")
+
+    with pytest.raises(ValueError, match=error):
+        client.pull("registry.example/repository:tag", outdir=str(tmp_path))
+
+    assert not (tmp_path / "artifact.txt").exists()
 
 
 @pytest.mark.with_auth(False)

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.42"
+__version__ = "0.2.43"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
We really _should_ be doing content verification when we download data from the registry. I believe other ORAS implementations do and certainly tools like Docker, Podman, etc. do. The OCI Spec(https://specs.opencontainers.org/image-spec/descriptor) says:

> Retrieved content SHOULD be verified against this digest when consumed via untrusted sources.

And then give guidance of what verification should check [here](https://github.com/opencontainers/image-spec/blob/main/descriptor.md?utm_source=chatgpt.com#verification).

Resolves #247 