### PR TITLE
Refactor/transport boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - add an asynchronous client, `oras.client.AsyncOrasClient`, backed by httpx through the new `async` extra. Registry decisions move to a shared `RegistryBase` so the synchronous and asynchronous providers share them rather than each holding a copy (0.2.46)
  - send authentication requests through the transport, and allow a transport to be given to `Registry`, so all registry traffic shares one place to execute requests and one set of connections (0.2.45)
  - move request execution behind an `oras.transport.Transport`, and add `get_manifest_content`/`upload_manifest_content` so `Layout` uses registry operations instead of raw requests (0.2.44)
  - route push completion output through the logger and support the documented `quiet` option, closes issue [229](https://github.com/oras-project/oras-py/issues/229) (0.2.43)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - fix the asynchronous blob upload sending an empty body when the request is retried: a body that can only be read once is now produced again for each attempt (0.2.47)
  - add an asynchronous client, `oras.client.AsyncOrasClient`, backed by httpx through the new `async` extra. Registry decisions move to a shared `RegistryBase` so the synchronous and asynchronous providers share them rather than each holding a copy (0.2.46)
  - send authentication requests through the transport, and allow a transport to be given to `Registry`, so all registry traffic shares one place to execute requests and one set of connections (0.2.45)
  - move request execution behind an `oras.transport.Transport`, and add `get_manifest_content`/`upload_manifest_content` so `Layout` uses registry operations instead of raw requests (0.2.44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - resolve a request body at the moment it is sent, so an asynchronous blob upload that is redirected by the registry re-reads the file instead of failing on a spent stream (0.2.48)
  - fix the asynchronous blob upload sending an empty body when the request is retried: a body that can only be read once is now produced again for each attempt (0.2.47)
  - add an asynchronous client, `oras.client.AsyncOrasClient`, backed by httpx through the new `async` extra. Registry decisions move to a shared `RegistryBase` so the synchronous and asynchronous providers share them rather than each holding a copy (0.2.46)
  - send authentication requests through the transport, and allow a transport to be given to `Registry`, so all registry traffic shares one place to execute requests and one set of connections (0.2.45)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - send authentication requests through the transport, and allow a transport to be given to `Registry`, so all registry traffic shares one place to execute requests and one set of connections (0.2.45)
  - move request execution behind an `oras.transport.Transport`, and add `get_manifest_content`/`upload_manifest_content` so `Layout` uses registry operations instead of raw requests (0.2.44)
  - route push completion output through the logger and support the documented `quiet` option, closes issue [229](https://github.com/oras-project/oras-py/issues/229) (0.2.43)
  - add Layout `copy` for pull_from_registry capability (0.2.42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - answer an authentication challenge when downloading a blob asynchronously, and retry a failed connection, so a streamed download is authenticated like every other request (0.2.49)
  - resolve a request body at the moment it is sent, so an asynchronous blob upload that is redirected by the registry re-reads the file instead of failing on a spent stream (0.2.48)
  - fix the asynchronous blob upload sending an empty body when the request is retried: a body that can only be read once is now produced again for each attempt (0.2.47)
  - add an asynchronous client, `oras.client.AsyncOrasClient`, backed by httpx through the new `async` extra. Registry decisions move to a shared `RegistryBase` so the synchronous and asynchronous providers share them rather than each holding a copy (0.2.46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - move request execution behind an `oras.transport.Transport`, and add `get_manifest_content`/`upload_manifest_content` so `Layout` uses registry operations instead of raw requests (0.2.44)
  - route push completion output through the logger and support the documented `quiet` option, closes issue [229](https://github.com/oras-project/oras-py/issues/229) (0.2.43)
  - add Layout `copy` for pull_from_registry capability (0.2.42)
  - make `get_manifest()` validation optional, fix `Accept` header join, and expand default `Accept` header types to cover all supported response types for the `/v2/<name>/manifests/<reference>` endpoint (0.2.41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - report a TLS failure straight away in the asynchronous retry, rather than sleeping through every attempt first, while still retrying a refused connection (0.2.50)
  - answer an authentication challenge when downloading a blob asynchronously, and retry a failed connection, so a streamed download is authenticated like every other request (0.2.49)
  - resolve a request body at the moment it is sent, so an asynchronous blob upload that is redirected by the registry re-reads the file instead of failing on a spent stream (0.2.48)
  - fix the asynchronous blob upload sending an empty body when the request is retried: a body that can only be read once is now produced again for each attempt (0.2.47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - refuse cookies in the asynchronous transport with a cookie policy rather than clearing them afterwards, so a streamed download or a redirect cannot leave one behind (0.2.51)
  - report a TLS failure straight away in the asynchronous retry, rather than sleeping through every attempt first, while still retrying a refused connection (0.2.50)
  - answer an authentication challenge when downloading a blob asynchronously, and retry a failed connection, so a streamed download is authenticated like every other request (0.2.49)
  - resolve a request body at the moment it is sent, so an asynchronous blob upload that is redirected by the registry re-reads the file instead of failing on a spent stream (0.2.48)

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -688,6 +688,57 @@ client = oras.client.OrasClient(auth_backend="ecr")
 client.pull(target="123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest")
 ```
 
+## Asynchronous Client
+
+There is an asynchronous client alongside the synchronous one. It needs `httpx`,
+which is an extra, so it is not installed unless you ask for it:
+
+```bash
+$ pip install oras[async]
+```
+
+The two clients are separate classes rather than one class with two modes, so
+whether a call is awaited is clear from the client you created. `AsyncOrasClient`
+owns a connection pool for its lifetime, so use it as a context manager, or call
+`aclose()` when you are done with it:
+
+```python
+import oras.client
+
+async with oras.client.AsyncOrasClient(hostname="localhost:5000", insecure=True) as client:
+    await client.push(files=["artifact.txt"], target="localhost:5000/dinosaur/artifact:v1")
+    files = await client.pull(target="localhost:5000/dinosaur/artifact:v1", outdir="pulled")
+```
+
+```python
+client = oras.client.AsyncOrasClient(hostname="localhost:5000", insecure=True)
+try:
+    manifest = await client.get_manifest("localhost:5000/dinosaur/artifact:v1")
+finally:
+    await client.aclose()
+```
+
+The registry operations are the asynchronous ones: `push`, `pull`, `get_manifest`,
+`get_manifest_content`, `upload_manifest`, `upload_manifest_content`, `upload_blob`,
+`download_blob`, `blob_exists`, `get_tags`, `delete_tag`, `delete_tags` and
+`do_request`. Reading and writing files on disk stays synchronous, because that is
+local work rather than something to wait on.
+
+Because a client holds one connection pool, operations on it can run together:
+
+```python
+import asyncio
+
+async with oras.client.AsyncOrasClient(hostname="localhost:5000", insecure=True) as client:
+    first, second = await asyncio.gather(
+        client.pull(target="localhost:5000/dinosaur/artifact:v1", outdir="one"),
+        client.pull(target="localhost:5000/dinosaur/other:v1", outdir="two"),
+    )
+```
+
+The synchronous client is unchanged and needs nothing new installed, so both APIs
+can be used from the same project.
+
 ## Custom Clients
 
 The benefit of Oras Python is that you can create a subclass that easily implements

--- a/oras/auth/__init__.py
+++ b/oras/auth/__init__.py
@@ -1,4 +1,4 @@
-import requests
+from oras.transport import Transport
 
 from .basic import BasicAuth
 from .ecr import EcrAuth
@@ -16,13 +16,33 @@ class AuthenticationException(Exception):
 
 
 def get_auth_backend(
-    name="token", session=None, insecure=False, tls_verify=True, **kwargs
+    name="token",
+    session=None,
+    insecure=False,
+    tls_verify=True,
+    transport=None,
+    **kwargs,
 ):
+    """
+    Get an auth backend by name, ready to send requests.
+
+    :param name: name of the backend to create
+    :type name: str
+    :param session: a session for the backend to use, if no transport is given
+    :type session: requests.Session
+    :param insecure: use http instead of https
+    :type insecure: bool
+    :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+    :type tls_verify: bool or str
+    :param transport: transport to send requests with, usually the provider's
+                      so that both share connections. One is created from the
+                      session and tls_verify when not provided
+    :type transport: oras.transport.Transport
+    """
     backend = auth_backends.get(name)
     if not backend:
         raise ValueError(f"Authentication backend {backend} is not known.")
     backend = backend(**kwargs)
-    backend.session = session or requests.Session()
+    backend.transport = transport or Transport(session=session, tls_verify=tls_verify)
     backend.prefix = "http" if insecure else "https"
-    backend._tls_verify = tls_verify
     return backend

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -58,6 +58,37 @@ class AuthBackend:
     def get_auth_header(self):
         raise NotImplementedError
 
+    def authenticate_request(self, original, headers: dict, refresh: bool = False):
+        """
+        Answer an authentication challenge. Backends decide how.
+
+        :param original: original response carrying the challenge
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param refresh: discard a cached token first
+        :type refresh: bool
+        """
+        raise NotImplementedError
+
+    async def authenticate_request_async(
+        self, original, headers: dict, refresh: bool = False
+    ):
+        """
+        Answer an authentication challenge for an asynchronous request.
+
+        The default is to reuse the synchronous answer, which is correct for
+        any backend that decides locally and sends no request of its own.
+        Backends that do talk to a token endpoint override this so the call is
+        awaited rather than blocking the event loop.
+
+        :param original: original response carrying the challenge
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param refresh: discard a cached token first
+        :type refresh: bool
+        """
+        return self.authenticate_request(original, headers, refresh)
+
     def get_container(self, name: container_type) -> oras.container.Container:
         """
         Courtesy function to get a container from a URI.

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -4,7 +4,7 @@ __license__ = "Apache-2.0"
 
 import json
 import subprocess
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 
@@ -12,20 +12,48 @@ import oras.auth.utils as auth_utils
 import oras.container
 import oras.decorator as decorator
 from oras.logger import logger
+from oras.transport import Transport
 from oras.types import container_type
 
 
 class AuthBackend:
     """
     Generic (and default) auth backend.
-    """
 
-    session: requests.Session
-    _tls_verify: bool
+    A backend decides how to answer an authentication challenge. It sends its
+    requests, such as fetching a token from a realm, through the same transport
+    the provider uses, so there is one place where requests are sent and one
+    set of connections to the registry.
+    """
 
     def __init__(self, *args, **kwargs):
         self._auth_config: dict = {}
         self.prefix: str = "https"
+
+        # Usually replaced with the provider's transport by get_auth_backend
+        self.transport = Transport()
+
+    @property
+    def session(self) -> requests.Session:
+        """
+        The session used to talk to the registry.
+        """
+        return self.transport.session
+
+    @session.setter
+    def session(self, session: requests.Session):
+        self.transport.session = session
+
+    @property
+    def _tls_verify(self) -> Union[bool, str]:
+        """
+        Whether tls verification is enabled, or the custom CA-Bundle in use.
+        """
+        return self.transport.tls_verify
+
+    @_tls_verify.setter
+    def _tls_verify(self, tls_verify: Union[bool, str]):
+        self.transport.tls_verify = tls_verify
 
     def get_auth_header(self):
         raise NotImplementedError
@@ -180,7 +208,7 @@ class AuthBackend:
             params["scope"] = h.scope
 
         logger.debug(f"Final params are {params}")
-        response = self.session.request("GET", h.realm, params=params)
+        response = self.transport.request(h.realm, "GET", params=params)  # type: ignore
         if response.status_code != 200:
             logger.debug(f"Response for anon token failed: {response.text}")
             return headers, False

--- a/oras/auth/base.py
+++ b/oras/auth/base.py
@@ -4,7 +4,7 @@ __license__ = "Apache-2.0"
 
 import json
 import subprocess
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 
@@ -12,20 +12,48 @@ import oras.auth.utils as auth_utils
 import oras.container
 import oras.decorator as decorator
 from oras.logger import logger
+from oras.transport import Transport
 from oras.types import container_type
 
 
 class AuthBackend:
     """
     Generic (and default) auth backend.
-    """
 
-    session: requests.Session
-    _tls_verify: bool
+    A backend decides how to answer an authentication challenge. It sends its
+    requests, such as fetching a token from a realm, through the same transport
+    the provider uses, so there is one place where requests are sent and one
+    set of connections to the registry.
+    """
 
     def __init__(self, *args, **kwargs):
         self._auth_config: dict = {}
         self.prefix: str = "https"
+
+        # Usually replaced with the provider's transport by get_auth_backend
+        self.transport = Transport()
+
+    @property
+    def session(self) -> requests.Session:
+        """
+        The session used to talk to the registry.
+        """
+        return self.transport.session
+
+    @session.setter
+    def session(self, session: requests.Session):
+        self.transport.session = session
+
+    @property
+    def _tls_verify(self) -> Union[bool, str]:
+        """
+        Whether tls verification is enabled, or the custom CA-Bundle in use.
+        """
+        return self.transport.tls_verify
+
+    @_tls_verify.setter
+    def _tls_verify(self, tls_verify: Union[bool, str]):
+        self.transport.tls_verify = tls_verify
 
     def get_auth_header(self):
         raise NotImplementedError
@@ -182,7 +210,7 @@ class AuthBackend:
             params["scope"] = h.scope
 
         logger.debug(f"Final params are {params}")
-        response = self.session.request("GET", h.realm, params=params)
+        response = self.transport.request(h.realm, "GET", params=params)  # type: ignore
         if response.status_code != 200:
             logger.debug(f"Response for anon token failed: {response.text}")
             return headers, False

--- a/oras/auth/ecr.py
+++ b/oras/auth/ecr.py
@@ -2,6 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import asyncio
 import re
 from typing import Optional
 
@@ -60,28 +61,100 @@ class EcrAuth(TokenAuth):
             return super().authenticate_request(original, headers, refresh)
         token = self._tokens.get(h.realm)
         if not token or refresh:
-            m = re.fullmatch(
-                self.AWS_ECR_REALM_PATTERN,
-                h.realm,
-            )
-            if not m:
-                logger.warning(f"realm: {h.realm} did not match expected pattern.")
+            region = self._region_for(h)
+            if region is None:
                 return super().request_token(h)
-            region = m.group("region")
-            try:
-                import boto3
-            except ImportError as e:
-                msg = """the `boto3` dependency is required to support authentication to this registry.
-                Make sure to install the required extra "ecr", e.g.: pip install oras[ecr].
-                """
-                raise ImportError(msg) from e
-            ecr = boto3.client("ecr", region_name=region)
-            auth = ecr.get_authorization_token()["authorizationData"][0]
-            token = auth.get("authorizationToken", "")
-            self._tokens[h.realm] = token
+            token = self._fetch_token(h.realm, region)
 
+        return self._authorization(headers, token), True
+
+    async def authenticate_request_async(self, original, headers: dict, refresh=False):
+        """
+        Answer a challenge for an asynchronous request.
+
+        A non-ECR realm is answered over the async transport by TokenAuth. An
+        ECR realm is answered by the AWS SDK, which is synchronous and has no
+        async equivalent without taking on another dependency. That one call is
+        run in a worker thread so it does not block the event loop; it happens
+        once per realm and the result is cached, so the cost is bounded.
+
+        :param original: original response to get the Www-Authenticate header
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param refresh: discard a cached token first
+        :type refresh: bool
+        """
+        headers = headers or {}
+        authHeaderRaw = original.headers.get("Www-Authenticate")
+        if not authHeaderRaw:
+            logger.debug(
+                "Www-Authenticate not found in original response, cannot authenticate."
+            )
+            return headers, False
+
+        h = auth_utils.parse_auth_header(authHeaderRaw)
+        if h.service != "ecr.amazonaws.com" or h.realm is None:
+            return await super().authenticate_request_async(original, headers, refresh)
+
+        token = self._tokens.get(h.realm)
+        if not token or refresh:
+            region = self._region_for(h)
+            if region is None:
+                return await super().request_token_async(h)
+            loop = asyncio.get_running_loop()
+            token = await loop.run_in_executor(None, self._fetch_token, h.realm, region)
+
+        return self._authorization(headers, token), True
+
+    def _region_for(self, h: auth_utils.authHeader) -> Optional[str]:
+        """
+        Get the AWS region a realm belongs to, if it looks like an ECR realm.
+
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        """
+        m = re.fullmatch(self.AWS_ECR_REALM_PATTERN, h.realm)  # type: ignore
+        if not m:
+            logger.warning(f"realm: {h.realm} did not match expected pattern.")
+            return None
+        return m.group("region")
+
+    def _fetch_token(self, realm: str, region: str) -> str:
+        """
+        Ask AWS for an authorization token, and remember it for the realm.
+
+        This is a blocking SDK call. Callers on an event loop run it in a
+        worker thread rather than awaiting it.
+
+        :param realm: the realm the token is for
+        :type realm: str
+        :param region: the AWS region to ask
+        :type region: str
+        """
+        try:
+            import boto3
+        except ImportError as e:
+            msg = """the `boto3` dependency is required to support authentication to this registry.
+            Make sure to install the required extra "ecr", e.g.: pip install oras[ecr].
+            """
+            raise ImportError(msg) from e
+        ecr = boto3.client("ecr", region_name=region)
+        auth = ecr.get_authorization_token()["authorizationData"][0]
+        token = auth.get("authorizationToken", "")
+        self._tokens[realm] = token
+        return token
+
+    def _authorization(self, headers: dict, token: str) -> dict:
+        """
+        Add the ECR token to the headers of the request being retried.
+
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param token: the authorization token from AWS
+        :type token: str
+        """
         result = {}
         if headers is not None:
             result.update(headers)
         result["Authorization"] = "Basic %s" % token
-        return result, True
+        return result

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -136,7 +136,7 @@ class TokenAuth(AuthBackend):
         logger.debug(
             f"Requesting auth token for: {h} with header keys: {list(headers.keys())}"
         )
-        authResponse = self.session.get(h.realm, headers=headers, params=params, verify=self._tls_verify)  # type: ignore
+        authResponse = self.transport.request(h.realm, "GET", headers=headers, params=params)  # type: ignore
 
         if authResponse.status_code != 200:
             logger.debug(f"Auth response was not successful: {authResponse.text}")
@@ -163,9 +163,7 @@ class TokenAuth(AuthBackend):
             params["scope"] = h.scope
 
         logger.debug(f"Requesting anon token with params: {params}")
-        response = self.session.request(
-            "GET", h.realm, params=params, verify=self._tls_verify
-        )
+        response = self.transport.request(h.realm, "GET", params=params)  # type: ignore
         if response.status_code != 200:
             logger.debug(f"Response for anon token failed: {response.text}")
             return

--- a/oras/auth/token.py
+++ b/oras/auth/token.py
@@ -2,6 +2,8 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+from typing import Optional
+
 import requests
 
 import oras.auth.utils as auth_utils
@@ -45,6 +47,66 @@ class TokenAuth(AuthBackend):
         if self._basic_auth:
             self.set_header("Authorization", "Basic %s" % self._basic_auth)
 
+    def _begin_challenge(self, original, headers: dict, refresh: bool):
+        """
+        Work out what answering a challenge requires, before any request.
+
+        This is the half of the flow that only makes decisions, so both the
+        synchronous and the asynchronous answer share it.
+
+        :param original: original response to get the Www-Authenticate header
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param refresh: discard a cached token first
+        :type refresh: bool
+        :return: (headers, parsed challenge, early result). When the early
+                 result is not None the caller is finished and returns it,
+                 either because there was no challenge or because a cached
+                 token already answers it.
+        """
+        headers = headers or {}
+        if refresh:
+            self.token = None
+        authHeaderRaw = original.headers.get("Www-Authenticate")
+        if not authHeaderRaw:
+            logger.debug(
+                "Www-Authenticate not found in original response, cannot authenticate."
+            )
+            return headers, None, (headers, False)
+
+        # If we have a token, set auth header (base64 encoded user/pass)
+        if self.token:
+            headers["Authorization"] = "Bearer %s" % self.token
+            return headers, None, (headers, True)
+
+        return headers, auth_utils.parse_auth_header(authHeaderRaw), None
+
+    def _accept_token(self, token: str, headers: dict):
+        """
+        Cache a token that was just obtained, and use it for the retry.
+
+        :param token: the bearer token
+        :type token: str
+        :param headers: headers of the request to retry
+        :type headers: dict
+        """
+        self.token = token
+        headers["Authorization"] = "Bearer %s" % self.token
+        return headers, True
+
+    def _no_token(self, headers: dict):
+        """
+        Report that a challenge could not be answered.
+
+        :param headers: headers of the request that was challenged
+        :type headers: dict
+        """
+        logger.error(
+            "This endpoint requires a token. Please use "
+            "basic auth with a username or password."
+        )
+        return headers, False
+
     def authenticate_request(
         self, original: requests.Response, headers: dict, refresh=False
     ):
@@ -57,48 +119,60 @@ class TokenAuth(AuthBackend):
         :param original: original response to get the Www-Authenticate header
         :type original: requests.Response
         """
-        headers = headers or {}
-        if refresh:
-            self.token = None
-        authHeaderRaw = original.headers.get("Www-Authenticate")
-        if not authHeaderRaw:
-            logger.debug(
-                "Www-Authenticate not found in original response, cannot authenticate."
-            )
-            return headers, False
-
-        # If we have a token, set auth header (base64 encoded user/pass)
-        if self.token:
-            headers["Authorization"] = "Bearer %s" % self.token
-            return headers, True
-
-        h = auth_utils.parse_auth_header(authHeaderRaw)
+        headers, h, early = self._begin_challenge(original, headers, refresh)
+        if early is not None:
+            return early
 
         # if no basic auth, try by request an anonymous token
         if not hasattr(self, "_basic_auth"):
             anon_token = self.request_anonymous_token(h)
             if anon_token:
                 logger.debug("Successfully obtained anonymous token!")
-                self.token = anon_token
-                headers["Authorization"] = "Bearer %s" % self.token
-                return headers, True
+                return self._accept_token(anon_token, headers)
 
         # basic auth is available, try using auth token
         token = self.request_token(h)
         if token:
-            self.token = token
-            headers["Authorization"] = "Bearer %s" % self.token
-            return headers, True
+            return self._accept_token(token, headers)
 
-        logger.error(
-            "This endpoint requires a token. Please use "
-            "basic auth with a username or password."
-        )
-        return headers, False
+        return self._no_token(headers)
 
-    def request_token(self, h: auth_utils.authHeader) -> bool:
+    async def authenticate_request_async(self, original, headers: dict, refresh=False):
         """
-        Request an authenticated token and save for later.
+        Answer a challenge without blocking the event loop.
+
+        The decisions are the same as the synchronous version, only the token
+        request is awaited.
+
+        :param original: original response to get the Www-Authenticate header
+        :param headers: headers of the request to retry
+        :type headers: dict
+        :param refresh: discard a cached token first
+        :type refresh: bool
+        """
+        headers, h, early = self._begin_challenge(original, headers, refresh)
+        if early is not None:
+            return early
+
+        if not hasattr(self, "_basic_auth"):
+            anon_token = await self.request_anonymous_token_async(h)
+            if anon_token:
+                logger.debug("Successfully obtained anonymous token!")
+                return self._accept_token(anon_token, headers)
+
+        token = await self.request_token_async(h)
+        if token:
+            return self._accept_token(token, headers)
+
+        return self._no_token(headers)
+
+    def _token_request(self, h: auth_utils.authHeader):
+        """
+        Build the request that asks a realm for a token.
+
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        :return: (realm, headers, params) for the token request
         """
         params = {}
         headers = {}
@@ -136,25 +210,35 @@ class TokenAuth(AuthBackend):
         logger.debug(
             f"Requesting auth token for: {h} with header keys: {list(headers.keys())}"
         )
-        authResponse = self.transport.request(h.realm, "GET", headers=headers, params=params)  # type: ignore
+        return h.realm, headers, params
 
-        if authResponse.status_code != 200:
-            logger.debug(f"Auth response was not successful: {authResponse.text}")
-            return
+    def _token_from_response(self, response) -> Optional[str]:
+        """
+        Read a token out of a realm's answer.
 
-        # Request the token
-        info = authResponse.json()
+        From https://docs.docker.com/registry/spec/auth/token/ we can get token
+        OR access_token OR both (when both they are identical).
+
+        :param response: the answer from the token realm
+        """
+        if response.status_code != 200:
+            logger.debug(f"Auth response was not successful: {response.text}")
+            return None
+
+        info = response.json()
         return info.get("token") or info.get("access_token")
 
-    def request_anonymous_token(self, h: auth_utils.authHeader) -> bool:
+    def _anonymous_token_request(self, h: auth_utils.authHeader):
         """
-        Given no basic auth, fall back to trying to request an anonymous token.
+        Build the request that asks a realm for an anonymous token.
 
-        Returns: boolean if headers have been updated with token.
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        :return: (realm, params), or None when there is no realm to ask
         """
         if not h.realm:
             logger.debug("Request anonymous token: no realm provided, exiting early")
-            return
+            return None
 
         params = {}
         if h.service:
@@ -163,17 +247,58 @@ class TokenAuth(AuthBackend):
             params["scope"] = h.scope
 
         logger.debug(f"Requesting anon token with params: {params}")
-        response = self.transport.request(h.realm, "GET", params=params)  # type: ignore
-        if response.status_code != 200:
-            logger.debug(f"Response for anon token failed: {response.text}")
-            return
+        return h.realm, params
 
-        # From https://docs.docker.com/registry/spec/auth/token/ section
-        # We can get token OR access_token OR both (when both they are identical)
-        data = response.json()
-        token = data.get("token") or data.get("access_token")
+    def request_token(self, h: auth_utils.authHeader) -> Optional[str]:
+        """
+        Request an authenticated token and save for later.
 
-        # Update the headers but not self.token (expects Basic)
-        if token:
-            return token
-        logger.debug("Warning: no token or access_token present in response.")
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        """
+        realm, headers, params = self._token_request(h)
+        response = self.transport.request(realm, "GET", headers=headers, params=params)  # type: ignore
+        return self._token_from_response(response)
+
+    async def request_token_async(self, h: auth_utils.authHeader) -> Optional[str]:
+        """
+        Request an authenticated token without blocking the event loop.
+
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        """
+        realm, headers, params = self._token_request(h)
+        response = await self.transport.request(realm, "GET", headers=headers, params=params)  # type: ignore
+        return self._token_from_response(response)
+
+    def request_anonymous_token(self, h: auth_utils.authHeader) -> Optional[str]:
+        """
+        Given no basic auth, fall back to trying to request an anonymous token.
+
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        """
+        request = self._anonymous_token_request(h)
+        if not request:
+            return None
+
+        realm, params = request
+        response = self.transport.request(realm, "GET", params=params)
+        return self._token_from_response(response)
+
+    async def request_anonymous_token_async(
+        self, h: auth_utils.authHeader
+    ) -> Optional[str]:
+        """
+        Request an anonymous token without blocking the event loop.
+
+        :param h: the parsed Www-Authenticate header
+        :type h: oras.auth.utils.authHeader
+        """
+        request = self._anonymous_token_request(h)
+        if not request:
+            return None
+
+        realm, params = request
+        response = await self.transport.request(realm, "GET", params=params)
+        return self._token_from_response(response)

--- a/oras/client.py
+++ b/oras/client.py
@@ -5,3 +5,18 @@ __license__ = "Apache-2.0"
 
 # Fallback support so OrasClient still works
 from .provider import Registry as OrasClient  # noqa
+
+
+def __getattr__(name):
+    """
+    Expose AsyncOrasClient without importing httpx unless it is asked for.
+
+    The async client needs httpx, which is an optional extra, so importing it
+    eagerly here would make `import oras.client` fail for anyone who installed
+    oras without that extra.
+    """
+    if name == "AsyncOrasClient":
+        from .provider_async import AsyncRegistry
+
+        return AsyncRegistry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -2,6 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import asyncio
 import time
 from functools import wraps
 
@@ -9,6 +10,39 @@ import requests.exceptions
 
 import oras.auth
 from oras.logger import logger
+from oras.transport import response_reason
+
+
+def check_5xx(res):
+    """
+    Raise if a response is a server error, after logging what the registry said.
+
+    Whether a response is worth retrying is a decision, not an execution
+    detail, so the synchronous and asynchronous retries share it.
+
+    :param res: the response to inspect
+    """
+    if res.status_code == 500:
+        try:
+            msg = res.json()
+            for error in msg.get("errors", []):
+                if isinstance(error, dict) and "message" in error:
+                    logger.error(error["message"])
+        except Exception:
+            pass
+        raise ValueError(f"Issue with {res.request.url}: {response_reason(res)}")
+
+
+def backoff_seconds(attempt: int, timeout: int) -> int:
+    """
+    How long to wait before retrying, shared by both retries.
+
+    :param attempt: how many attempts have already failed
+    :type attempt: int
+    :param timeout: the base wait
+    :type timeout: int
+    """
+    return timeout + 3**attempt
 
 
 def ensure_container(func):
@@ -40,26 +74,55 @@ def retry(attempts=5, timeout=2):
             while attempt < attempts:
                 try:
                     res = func(*args, **kwargs)
-                    if res.status_code == 500:
-                        try:
-                            msg = res.json()
-                            for error in msg.get("errors", []):
-                                if isinstance(error, dict) and "message" in error:
-                                    logger.error(error["message"])
-                        except Exception:
-                            pass
-                        raise ValueError(f"Issue with {res.request.url}: {res.reason}")
+                    check_5xx(res)
                     return res
                 except oras.auth.AuthenticationException as e:
                     raise e
                 except (requests.exceptions.SSLError, ImportError):
                     raise
                 except Exception as e:
-                    sleep = timeout + 3**attempt
+                    sleep = backoff_seconds(attempt, timeout)
                     logger.info(f"Retrying in {sleep} seconds - error: {e}")
                     time.sleep(sleep)
                     attempt += 1
             return func(*args, **kwargs)
+
+        return inner
+
+    return decorator
+
+
+def retry_async(attempts=5, timeout=2):
+    """
+    The asynchronous counterpart to retry.
+
+    The policy is the same and is shared through check_5xx and
+    backoff_seconds; only waiting and calling differ, since neither can be
+    written once for both execution models.
+
+    asyncio.CancelledError derives from BaseException, so `except Exception`
+    does not catch it and a cancelled request stops retrying immediately.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        async def inner(*args, **kwargs):
+            attempt = 0
+            while attempt < attempts:
+                try:
+                    res = await func(*args, **kwargs)
+                    check_5xx(res)
+                    return res
+                except oras.auth.AuthenticationException as e:
+                    raise e
+                except ImportError:
+                    raise
+                except Exception as e:
+                    sleep = backoff_seconds(attempt, timeout)
+                    logger.info(f"Retrying in {sleep} seconds - error: {e}")
+                    await asyncio.sleep(sleep)
+                    attempt += 1
+            return await func(*args, **kwargs)
 
         return inner
 

--- a/oras/decorator.py
+++ b/oras/decorator.py
@@ -3,8 +3,10 @@ __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 import asyncio
+import ssl
 import time
 from functools import wraps
+from typing import Optional
 
 import requests.exceptions
 
@@ -31,6 +33,29 @@ def check_5xx(res):
         except Exception:
             pass
         raise ValueError(f"Issue with {res.request.url}: {response_reason(res)}")
+
+
+def is_certificate_error(error: BaseException) -> bool:
+    """
+    Whether a failure is a TLS problem rather than something transient.
+
+    requests raises a distinct SSLError, which the synchronous retry re-raises
+    at once: a bad certificate or the wrong hostname will not fix itself, and
+    sleeping through the attempts only delays the message. httpx has no such
+    class - a certificate failure and a refused connection are both a
+    ConnectError - so the cause chain is what tells them apart. A refused
+    connection is still worth retrying; a certificate is not.
+
+    :param error: the exception a request raised
+    """
+    seen = set()
+    cause: Optional[BaseException] = error
+    while cause is not None and id(cause) not in seen:
+        seen.add(id(cause))
+        if isinstance(cause, ssl.SSLError):
+            return True
+        cause = cause.__cause__ or cause.__context__
+    return False
 
 
 def backoff_seconds(attempt: int, timeout: int) -> int:
@@ -118,6 +143,12 @@ def retry_async(attempts=5, timeout=2):
                 except ImportError:
                     raise
                 except Exception as e:
+                    # httpx reports a bad certificate as an ordinary
+                    # ConnectError, so it has to be recognised rather than
+                    # caught by class, or it would sleep through every attempt
+                    # before the user is told the certificate is wrong.
+                    if is_certificate_error(e):
+                        raise
                     sleep = backoff_seconds(attempt, timeout)
                     logger.info(f"Retrying in {sleep} seconds - error: {e}")
                     await asyncio.sleep(sleep)

--- a/oras/layout/layout.py
+++ b/oras/layout/layout.py
@@ -366,12 +366,11 @@ class Layout:
             sub_media_type = sub_manifest_ref.get(
                 "mediaType", oras.defaults.default_manifest_media_type
             )
-            headers = {"Accept": sub_media_type}
-            sub_url = f"{provider.prefix}://{container.registry}/v2/{container.api_prefix}/manifests/{sub_digest}"
-            response = provider.do_request(sub_url, "GET", headers=headers)
-            provider._check_200_response(response)
-
-            sub_bytes = response.content
+            sub_bytes, _ = provider.get_manifest_content(
+                container,
+                allowed_media_type=[sub_media_type],
+                reference=sub_digest,
+            )
             sub_data = json.loads(sub_bytes)
             # the Index might have defaulted, so we overwrite with the actual content response
             sub_media_type = sub_data.get("mediaType", "")
@@ -474,23 +473,20 @@ class Layout:
                     content_type = blob_data.get(
                         "mediaType", oras.defaults.default_manifest_media_type
                     )
-                    headers = {"Content-Type": content_type}
 
                     if is_last_blob:
                         # Final manifest/index - upload with tag
                         logger.debug(f"Uploading manifest/index with tag: {digest}")
-                        url = f"{provider.prefix}://{container.manifest_url()}"
-                        response = provider.do_request(
-                            url, "PUT", headers=headers, data=manifest_bytes
+                        response = provider.upload_manifest_content(
+                            manifest_bytes, container, content_type
                         )
                     else:
                         # Intermediate manifest - upload by digest only (no tag yet)
                         logger.debug(
                             f"Uploading intermediate manifest by digest: {digest}"
                         )
-                        url = f"{provider.prefix}://{container.registry}/v2/{container.api_prefix}/manifests/{digest}"
-                        response = provider.do_request(
-                            url, "PUT", headers=headers, data=manifest_bytes
+                        response = provider.upload_manifest_content(
+                            manifest_bytes, container, content_type, reference=digest
                         )
                 else:
                     # It's JSON but not a Image/Index Manifest, upload as blob with layer dict
@@ -549,17 +545,10 @@ class Layout:
         blobs_dir = layout_dir / oras.defaults.oci_blobs_dir / "sha256"
         blobs_dir.mkdir(parents=True, exist_ok=True)
 
-        headers = {
-            "Accept": ", ".join(oras.defaults.default_manifest_accepted_media_types)
-        }
-        manifest_url = f"{provider.prefix}://{container.manifest_url()}"
-        response = provider.do_request(manifest_url, "GET", headers=headers)
-        provider._check_200_response(response)
+        manifest_bytes, digest = provider.get_manifest_content(container)
 
-        manifest_bytes = response.content
-        manifest_digest = response.headers.get(
-            "Docker-Content-Digest", container.digest
-        )
+        # Fall back to the digest from the reference if the registry did not report one
+        manifest_digest = digest if digest is not None else container.digest
         if not manifest_digest:
             raise RuntimeError(
                 "Expected to find Docker-Content-Digest header in manifest response."

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -88,6 +88,22 @@ class RegistryBase:
     def __str__(self) -> str:
         return "[oras-client]"
 
+    def _request_body(self, data):
+        """
+        Produce the body to send for one attempt at a request.
+
+        A request can be sent more than once: to answer an authentication
+        challenge, to refresh a token after a 403, or because the retry
+        decorator tried again. A body that can only be read once - a file
+        object, or an iterator over a file - is empty by the second attempt,
+        while Content-Length and the digest still describe the first. Callers
+        with such a body pass a callable that produces a fresh one, and it is
+        invoked per attempt. Anything re-readable is passed through untouched.
+
+        :param data: the body, or a callable returning a fresh body
+        """
+        return data() if callable(data) else data
+
     def _url(self, path: str) -> str:
         """
         Prefix a registry path (e.g., from a Container) with the scheme in use.
@@ -1218,7 +1234,7 @@ class Registry(RegistryBase):
         self,
         url: str,
         method: str = "GET",
-        data: Optional[Union[dict, bytes]] = None,
+        data: Optional[Union[dict, bytes, Callable]] = None,
         headers: Optional[dict] = None,
         json: Optional[dict] = None,
         stream: bool = False,
@@ -1230,8 +1246,10 @@ class Registry(RegistryBase):
         :type url: str
         :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
         :type method: str
-        :param data: data for requests
-        :type data: dict or bytes
+        :param data: data for requests. A body that can only be read once
+                     must be given as a callable returning a fresh one,
+                     since the request may be sent again
+        :type data: dict or bytes or callable
         :param headers: headers for the request
         :type headers: dict
         :param json: json data for requests
@@ -1246,7 +1264,12 @@ class Registry(RegistryBase):
         if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
             headers.update(self.auth.get_auth_header())
         response = self.transport.request(
-            url, method, data=data, headers=headers, json=json, stream=stream
+            url,
+            method,
+            data=self._request_body(data),
+            headers=headers,
+            json=json,
+            stream=stream,
         )
 
         # A 401 response is a request for authentication, 404 is not found
@@ -1258,7 +1281,12 @@ class Registry(RegistryBase):
         if not changed:
             raise ValueError("Cannot respond to request for authentication.")
         response = self.transport.request(
-            url, method, data=data, headers=headers, json=json, stream=stream
+            url,
+            method,
+            data=self._request_body(data),
+            headers=headers,
+            json=json,
+            stream=stream,
         )
 
         # One retry if 403 denied (need new token?)
@@ -1267,7 +1295,12 @@ class Registry(RegistryBase):
                 response, headers, refresh=True
             )
             response = self.transport.request(
-                url, method, data=data, headers=headers, json=json, stream=stream
+                url,
+                method,
+                data=self._request_body(data),
+                headers=headers,
+                json=json,
+                stream=stream,
             )
 
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -50,6 +50,7 @@ class Registry:
         insecure: bool = False,
         tls_verify: Union[bool, str] = True,
         auth_backend: str = "token",
+        transport: Optional[Transport] = None,
     ):
         """
         Create an ORAS client.
@@ -64,17 +65,22 @@ class Registry:
         :type tls_verify: bool
         :param auth_backend: name of the auth backend to use
         :type auth_backend: str
+        :param transport: how to send requests, defaults to a new transport
+                          configured with tls_verify. A provided transport is
+                          used as given, so it carries its own tls settings
+        :type transport: oras.transport.Transport
         """
         self.hostname: Optional[str] = hostname
         self.headers: dict = {}
         self.prefix: str = "http" if insecure else "https"
 
         # The transport owns the session and how requests are sent
-        self.transport = Transport(tls_verify=tls_verify)
+        self.transport = transport or Transport(tls_verify=tls_verify)
 
-        # Get custom backend, pass on session to share
+        # The auth backend shares the transport, so a token request and a
+        # registry request reuse the same connections
         self.auth = oras.auth.get_auth_backend(
-            auth_backend, self.session, insecure, tls_verify=tls_verify
+            auth_backend, insecure=insecure, transport=self.transport
         )
 
     @property
@@ -98,6 +104,16 @@ class Registry:
     @_tls_verify.setter
     def _tls_verify(self, tls_verify: Union[bool, str]):
         self.transport.tls_verify = tls_verify
+
+    def close(self):
+        """
+        Release the connections held by the transport.
+
+        Calling this is optional, and a client is not required to be used as a
+        context manager. It is here for callers that create many clients and
+        want the pooled connections closed promptly.
+        """
+        self.transport.close()
 
     def __repr__(self) -> str:
         return str(self)

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -8,7 +8,6 @@ import sys
 import urllib
 from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
-from http.cookiejar import DefaultCookiePolicy
 from tempfile import TemporaryDirectory
 from typing import Callable, Generator, List, Optional, Tuple, Union
 
@@ -24,6 +23,7 @@ import oras.oci
 import oras.schemas
 import oras.utils
 from oras.logger import logger
+from oras.transport import Transport, successful_response
 from oras.types import container_type
 from oras.utils.fileio import PathAndOptionalContent
 
@@ -67,28 +67,52 @@ class Registry:
         """
         self.hostname: Optional[str] = hostname
         self.headers: dict = {}
-        self.session: requests.Session = requests.Session()
         self.prefix: str = "http" if insecure else "https"
-        self._tls_verify = tls_verify
 
-        if not tls_verify:
-            requests.packages.urllib3.disable_warnings()  # type: ignore
-
-        # Ignore all cookies: some registries try to set one
-        # and take it as a sign they are talking to a browser,
-        # trying to set further CSRF cookies (Harbor is such a case)
-        self.session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
+        # The transport owns the session and how requests are sent
+        self.transport = Transport(tls_verify=tls_verify)
 
         # Get custom backend, pass on session to share
         self.auth = oras.auth.get_auth_backend(
             auth_backend, self.session, insecure, tls_verify=tls_verify
         )
 
+    @property
+    def session(self) -> requests.Session:
+        """
+        The session used to interact with the registry.
+        """
+        return self.transport.session
+
+    @session.setter
+    def session(self, session: requests.Session):
+        self.transport.session = session
+
+    @property
+    def _tls_verify(self) -> Union[bool, str]:
+        """
+        Whether tls verification is enabled, or the custom CA-Bundle in use.
+        """
+        return self.transport.tls_verify
+
+    @_tls_verify.setter
+    def _tls_verify(self, tls_verify: Union[bool, str]):
+        self.transport.tls_verify = tls_verify
+
     def __repr__(self) -> str:
         return str(self)
 
     def __str__(self) -> str:
         return "[oras-client]"
+
+    def _url(self, path: str) -> str:
+        """
+        Prefix a registry path (e.g., from a Container) with the scheme in use.
+
+        :param path: the registry path, without a scheme
+        :type path: str
+        """
+        return f"{self.prefix}://{path}"
 
     def version(self, return_items: bool = False) -> Union[dict, str]:
         """
@@ -280,9 +304,7 @@ class Registry:
 
         if self.blob_exists(layer, container):
             logger.debug(f'layer already exists: {layer["digest"]}')
-            response = requests.Response()
-            response.status_code = 200
-            return response
+            return successful_response()
 
         # Chunked for large, otherwise POST and PUT
         # This is currently disabled unless the user asks for it, as
@@ -302,8 +324,7 @@ class Registry:
             response.status_code not in [200, 201, 202]
             and layer["digest"] == oras.defaults.blank_hash
         ):
-            response = requests.Response()
-            response.status_code = 200
+            response = successful_response()
         return response
 
     @decorator.ensure_container
@@ -318,7 +339,7 @@ class Registry:
         """
         logger.debug(f"Deleting tag {tag} for {container}")
 
-        head_url = f"{self.prefix}://{container.manifest_url(tag)}"  # type: ignore
+        head_url = self._url(container.manifest_url(tag))  # type: ignore
 
         # get digest of manifest to delete
         response = self.do_request(
@@ -334,7 +355,7 @@ class Registry:
         if not digest:
             raise RuntimeError("Expected to find Docker-Content-Digest header.")
 
-        delete_url = f"{self.prefix}://{container.manifest_url(digest)}"  # type: ignore
+        delete_url = self._url(container.manifest_url(digest))  # type: ignore
         response = self.do_request(delete_url, "DELETE")
         if response.status_code != 202:
             raise RuntimeError(f"Delete was not successful: {response.json()}")
@@ -351,7 +372,7 @@ class Registry:
         :type N: Optional[int]
         """
         retrieve_all = N is None
-        tags_url = f"{self.prefix}://{container.tags_url(N=N)}"  # type: ignore
+        tags_url = self._url(container.tags_url(N=N))  # type: ignore
         tags: List[str] = []
 
         def extract_tags(response: requests.Response):
@@ -425,7 +446,7 @@ class Registry:
         :type head: bool
         """
         method = "GET" if not head else "HEAD"
-        blob_url = f"{self.prefix}://{container.get_blob_url(digest)}"  # type: ignore
+        blob_url = self._url(container.get_blob_url(digest))  # type: ignore
         return self.do_request(blob_url, method, headers=self.headers, stream=stream)
 
     def get_container(self, name: container_type) -> oras.container.Container:
@@ -533,15 +554,9 @@ class Registry:
         :type layer: dict
         """
         # Start an upload session
-        headers = {"Content-Type": "application/octet-stream"}
-
-        upload_url = f"{self.prefix}://{container.upload_blob_url()}"
-        r = self.do_request(upload_url, "POST", headers=headers)
-
-        # Location should be in the header
-        session_url = self._get_location(r, container)
-        if not session_url:
-            raise ValueError(f"Issue retrieving session url: {r.json()}")
+        session_url = self._start_upload_session(
+            container, {"Content-Type": "application/octet-stream"}
+        )
 
         # PUT to upload blob url
         headers = {
@@ -571,7 +586,7 @@ class Registry:
         :type container: oras.container.Container
         """
         blob_url = container.get_blob_url(layer["digest"])
-        response = self.do_request(f"{self.prefix}://{blob_url}", "HEAD")
+        response = self.do_request(self._url(blob_url), "HEAD")
         return response.status_code == 200
 
     def _get_location(
@@ -600,6 +615,39 @@ class Registry:
             session_url = f"{prefix}{session_url}"
         return session_url
 
+    def _require_location(
+        self, r: requests.Response, container: oras.container.Container
+    ) -> str:
+        """
+        Parse the location header, and require that one was provided.
+
+        :param r: requests response with headers
+        :type r: requests.Response
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        """
+        session_url = self._get_location(r, container)
+        if not session_url:
+            raise ValueError(f"Issue retrieving session url: {r.json()}")
+        return session_url
+
+    def _start_upload_session(
+        self, container: oras.container.Container, headers: dict
+    ) -> str:
+        """
+        Open a blob upload session and return the url to upload to.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param headers: headers to start the session with
+        :type headers: dict
+        """
+        upload_url = self._url(container.upload_blob_url())
+        r = self.do_request(upload_url, "POST", headers=headers)
+
+        # Location should be in the header
+        return self._require_location(r, container)
+
     def chunked_upload(
         self,
         blob: str,
@@ -622,14 +670,7 @@ class Registry:
         # Start an upload session
         headers = {"Content-Type": "application/octet-stream", "Content-Length": "0"}
         headers.update(self.headers)
-
-        upload_url = f"{self.prefix}://{container.upload_blob_url()}"
-        r = self.do_request(upload_url, "POST", headers=headers)
-
-        # Location should be in the header
-        session_url = self._get_location(r, container)
-        if not session_url:
-            raise ValueError(f"Issue retrieving session url: {r.json()}")
+        session_url = self._start_upload_session(container, headers)
 
         # Read the blob in chunks, for each do a patch
         start = 0
@@ -652,9 +693,7 @@ class Registry:
                         session_url, "PATCH", data=chunk, headers=headers
                     )
                 )
-                session_url = self._get_location(r, container)
-                if not session_url:
-                    raise ValueError(f"Issue retrieving session url: {r.json()}")
+                session_url = self._require_location(r, container)
 
         # Finally, issue a PUT request to close blob
         session_url = oras.utils.append_url_params(
@@ -706,10 +745,42 @@ class Registry:
             "Content-Type": oras.defaults.default_manifest_media_type,
         }
         return self.do_request(
-            f"{self.prefix}://{container.manifest_url()}",  # noqa
+            self._url(container.manifest_url()),  # noqa
             "PUT",
             headers=headers,
             json=manifest,
+        )
+
+    def upload_manifest_content(
+        self,
+        content: bytes,
+        container: oras.container.Container,
+        media_type: str,
+        reference: Optional[str] = None,
+    ) -> requests.Response:
+        """
+        Upload a manifest from the exact bytes it should be stored as.
+
+        Unlike upload_manifest, the content is sent verbatim rather than being
+        serialized from a dict, so the digest of what the registry stores is the
+        digest of what was handed over. This matters when the manifest was
+        produced elsewhere, for example when copying from an OCI layout.
+
+        :param content: the raw manifest (or index) bytes to upload
+        :type content: bytes
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param media_type: media type of the manifest, used as the Content-Type
+        :type media_type: str
+        :param reference: tag or digest to upload to, defaults to the container reference
+        :type reference: str
+        """
+        headers = {"Content-Type": media_type}
+        return self.do_request(
+            self._url(container.manifest_url(reference)),
+            "PUT",
+            headers=headers,
+            data=content,
         )
 
     def push(
@@ -937,6 +1008,40 @@ class Registry:
         return files
 
     @decorator.ensure_container
+    def get_manifest_content(
+        self,
+        container: container_type,
+        allowed_media_type: Optional[list] = None,
+        reference: Optional[str] = None,
+    ) -> Tuple[bytes, Optional[str]]:
+        """
+        Retrieve a manifest as the raw bytes the registry served, with its digest.
+
+        get_manifest parses the manifest into a dict, which is what most callers
+        want. Use this instead when the bytes themselves matter - re-serializing
+        a parsed manifest can change its digest - such as when storing a manifest
+        in an OCI layout.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param allowed_media_type: one or more allowed media types
+        :type allowed_media_type: list
+        :param reference: tag or digest to retrieve, defaults to the container reference
+        :type reference: str
+        :return: tuple of the raw manifest bytes, and the digest reported by the
+                 registry in the Docker-Content-Digest header (None if absent)
+        """
+        if not allowed_media_type:
+            allowed_media_type = oras.defaults.default_manifest_accepted_media_types
+        headers = {"Accept": ", ".join(allowed_media_type)}
+
+        manifest_url = self._url(container.manifest_url(reference))  # type: ignore
+        response = self.do_request(manifest_url, "GET", headers=headers)
+
+        self._check_200_response(response)
+        return response.content, response.headers.get("Docker-Content-Digest")
+
+    @decorator.ensure_container
     def get_manifest(
         self,
         container: container_type,
@@ -961,7 +1066,7 @@ class Registry:
             allowed_media_type = oras.defaults.default_manifest_accepted_media_types
         headers = {"Accept": ", ".join(allowed_media_type)}
 
-        get_manifest = f"{self.prefix}://{container.manifest_url()}"  # type: ignore
+        get_manifest = self._url(container.manifest_url())  # type: ignore
         response = self.do_request(get_manifest, "GET", headers=headers)
 
         self._check_200_response(response)
@@ -1002,14 +1107,8 @@ class Registry:
         # Make the request and return to calling function, but attempt to use auth token if previously obtained
         if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
             headers.update(self.auth.get_auth_header())
-        response = self.session.request(
-            method,
-            url,
-            data=data,
-            json=json,
-            headers=headers,
-            stream=stream,
-            verify=self._tls_verify,
+        response = self.transport.request(
+            url, method, data=data, headers=headers, json=json, stream=stream
         )
 
         # A 401 response is a request for authentication, 404 is not found
@@ -1020,14 +1119,8 @@ class Registry:
         headers, changed = self.auth.authenticate_request(response, headers)
         if not changed:
             raise ValueError("Cannot respond to request for authentication.")
-        response = self.session.request(
-            method,
-            url,
-            data=data,
-            json=json,
-            headers=headers,
-            stream=stream,
-            verify=self._tls_verify,
+        response = self.transport.request(
+            url, method, data=data, headers=headers, json=json, stream=stream
         )
 
         # One retry if 403 denied (need new token?)
@@ -1035,14 +1128,8 @@ class Registry:
             headers, changed = self.auth.authenticate_request(
                 response, headers, refresh=True
             )
-            response = self.session.request(
-                method,
-                url,
-                data=data,
-                json=json,
-                headers=headers,
-                stream=stream,
-                verify=self._tls_verify,
+            response = self.transport.request(
+                url, method, data=data, headers=headers, json=json, stream=stream
             )
 
         return response

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -88,22 +88,6 @@ class RegistryBase:
     def __str__(self) -> str:
         return "[oras-client]"
 
-    def _request_body(self, data):
-        """
-        Produce the body to send for one attempt at a request.
-
-        A request can be sent more than once: to answer an authentication
-        challenge, to refresh a token after a 403, or because the retry
-        decorator tried again. A body that can only be read once - a file
-        object, or an iterator over a file - is empty by the second attempt,
-        while Content-Length and the digest still describe the first. Callers
-        with such a body pass a callable that produces a fresh one, and it is
-        invoked per attempt. Anything re-readable is passed through untouched.
-
-        :param data: the body, or a callable returning a fresh body
-        """
-        return data() if callable(data) else data
-
     def _url(self, path: str) -> str:
         """
         Prefix a registry path (e.g., from a Container) with the scheme in use.
@@ -1266,7 +1250,7 @@ class Registry(RegistryBase):
         response = self.transport.request(
             url,
             method,
-            data=self._request_body(data),
+            data=data,
             headers=headers,
             json=json,
             stream=stream,
@@ -1283,7 +1267,7 @@ class Registry(RegistryBase):
         response = self.transport.request(
             url,
             method,
-            data=self._request_body(data),
+            data=data,
             headers=headers,
             json=json,
             stream=stream,
@@ -1297,7 +1281,7 @@ class Registry(RegistryBase):
             response = self.transport.request(
                 url,
                 method,
-                data=self._request_body(data),
+                data=data,
                 headers=headers,
                 json=json,
                 stream=stream,

--- a/oras/provider.py
+++ b/oras/provider.py
@@ -9,7 +9,7 @@ import urllib
 from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
 from tempfile import TemporaryDirectory
-from typing import Callable, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Generator, List, Optional, Tuple, Union
 
 import jsonschema
 import requests
@@ -23,7 +23,7 @@ import oras.oci
 import oras.schemas
 import oras.utils
 from oras.logger import logger
-from oras.transport import Transport, successful_response
+from oras.transport import Transport, response_reason, successful_response
 from oras.types import container_type
 from oras.utils.fileio import PathAndOptionalContent
 
@@ -36,84 +36,51 @@ def temporary_empty_config() -> Generator[str, None, None]:
         yield config_file
 
 
-class Registry:
+class RegistryBase:
     """
-    Direct interactions with an OCI registry.
+    Registry behaviour that does not depend on how requests are executed.
 
-    This could also be called a "provider" when we add in the "copy" logic
-    and the registry isn't necessarily the "remote" endpoint.
+    This holds the decisions - how a url is built, how a layer is prepared from
+    a file, which media type applies, what a response means - and deliberately
+    holds none of the execution. Subclasses add the calls that talk to the
+    registry, synchronously in :class:`Registry` and asynchronously in
+    :class:`oras.provider_async.AsyncRegistry`.
+
+    The split exists so that changing a registry decision is a change in one
+    place, rather than the same change made once per execution model.
     """
 
     def __init__(
         self,
+        transport: Any,
         hostname: Optional[str] = None,
         insecure: bool = False,
-        tls_verify: Union[bool, str] = True,
         auth_backend: str = "token",
-        transport: Optional[Transport] = None,
     ):
         """
-        Create an ORAS client.
+        Wire up the pieces that both execution models share.
 
-        The hostname is the remote registry to ping.
+        The transport is required, and is what decides whether this provider
+        talks to the registry synchronously or asynchronously.
 
+        :param transport: the transport used to carry out requests
         :param hostname: the hostname of the registry to ping
         :type hostname: str
         :param insecure: use http instead of https
         :type insecure: bool
-        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
-        :type tls_verify: bool
         :param auth_backend: name of the auth backend to use
         :type auth_backend: str
-        :param transport: how to send requests, defaults to a new transport
-                          configured with tls_verify. A provided transport is
-                          used as given, so it carries its own tls settings
-        :type transport: oras.transport.Transport
         """
         self.hostname: Optional[str] = hostname
         self.headers: dict = {}
         self.prefix: str = "http" if insecure else "https"
-
-        # The transport owns the session and how requests are sent
-        self.transport = transport or Transport(tls_verify=tls_verify)
+        self.transport = transport
 
         # The auth backend shares the transport, so a token request and a
         # registry request reuse the same connections
         self.auth = oras.auth.get_auth_backend(
             auth_backend, insecure=insecure, transport=self.transport
         )
-
-    @property
-    def session(self) -> requests.Session:
-        """
-        The session used to interact with the registry.
-        """
-        return self.transport.session
-
-    @session.setter
-    def session(self, session: requests.Session):
-        self.transport.session = session
-
-    @property
-    def _tls_verify(self) -> Union[bool, str]:
-        """
-        Whether tls verification is enabled, or the custom CA-Bundle in use.
-        """
-        return self.transport.tls_verify
-
-    @_tls_verify.setter
-    def _tls_verify(self, tls_verify: Union[bool, str]):
-        self.transport.tls_verify = tls_verify
-
-    def close(self):
-        """
-        Release the connections held by the transport.
-
-        Calling this is optional, and a client is not required to be used as a
-        context manager. It is here for callers that create many clients and
-        want the pooled connections closed promptly.
-        """
-        self.transport.close()
 
     def __repr__(self) -> str:
         return str(self)
@@ -153,25 +120,6 @@ class Registry:
         # Otherwise return a string that can be printed
         return "\n".join(["%s: %s" % (k, v) for k, v in versions.items()])
 
-    def delete_tags(self, name: str, tags=Union[str, list]) -> List[str]:
-        """
-        Delete one or more tags for a unique resource identifier.
-
-        Returns those successfully deleted.
-
-        :param name: container URI to parse
-        :type name: str
-        :param tags: single or multiple tags name to delete
-        :type N: string or list
-        """
-        if isinstance(tags, str):
-            tags = [tags]
-        deleted = []
-        for tag in tags:
-            if self.delete_tag(name, tag):
-                deleted.append(tag)
-        return deleted
-
     def logout(self, hostname: str):
         """
         If auths are loaded, remove a hostname.
@@ -192,6 +140,9 @@ class Registry:
     ) -> dict:
         """
         Login to a registry.
+
+        This writes credentials to a docker config, it does not talk to the
+        registry, so it is the same for both execution models.
 
         :param username: the user account name
         :type username: str
@@ -260,6 +211,17 @@ class Registry:
         """
         self.headers.update({name: value})
 
+    def get_container(self, name: container_type) -> oras.container.Container:
+        """
+        Courtesy function to get a container from a URI.
+
+        :param name: unique resource identifier to parse
+        :type name: oras.container.Container or str
+        """
+        if isinstance(name, oras.container.Container):
+            return name
+        return oras.container.Container(name, registry=self.hostname)
+
     def _validate_path(self, path: str) -> bool:
         """
         Ensure a blob path is in the present working directory or below.
@@ -288,6 +250,322 @@ class Registry:
         if not path_content.content:
             path_content.content = oras.defaults.unknown_config_media_type
         return path_content.path, path_content.content
+
+    def _get_location(self, r, container: oras.container.Container) -> str:
+        """
+        Parse the location header and ensure it includes a hostname.
+        This currently assumes if there isn't a hostname, we are pushing to
+        the same registry hostname of the original request.
+
+        :param r: response with headers
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        """
+        session_url = r.headers.get("location", "")
+        if not session_url:
+            return session_url
+
+        # Some registries do not return the full registry hostname.  Check that
+        # the url starts with a protocol scheme, change tracked with:
+        # https://github.com/oras-project/oras-py/issues/78
+        prefix = f"{self.prefix}://{container.registry}"
+
+        if not session_url.startswith("http"):
+            session_url = f"{prefix}{session_url}"
+        return session_url
+
+    def _require_location(self, r, container: oras.container.Container) -> str:
+        """
+        Parse the location header, and require that one was provided.
+
+        :param r: response with headers
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        """
+        session_url = self._get_location(r, container)
+        if not session_url:
+            raise ValueError(f"Issue retrieving session url: {r.json()}")
+        return session_url
+
+    def _check_200_response(self, response):
+        """
+        Helper function to ensure some flavor of 200
+
+        :param response: request response to inspect
+        """
+        if response.status_code not in [200, 201, 202]:
+            self._parse_response_errors(response)
+            raise ValueError(
+                f"Issue with {response.request.url}: {response_reason(response)}"
+            )
+
+    def _parse_response_errors(self, response):
+        """
+        Given a failed request, look for OCI formatted error messages.
+
+        :param response: request response to inspect
+        """
+        try:
+            msg = response.json()
+            for error in msg.get("errors", []):
+                if isinstance(error, dict) and "message" in error:
+                    logger.error(error["message"])
+        except Exception:
+            pass
+
+    def _iter_push_layers(
+        self,
+        files: List,
+        annotset: oras.oci.Annotations,
+        disable_path_validation: bool,
+    ) -> Generator[Tuple[str, dict, bool], None, None]:
+        """
+        Prepare each file for upload, yielding what push needs to upload it.
+
+        Everything a push decides about a file happens here: splitting an
+        optional media type off the path, validating it, compressing a
+        directory, and building the layer with its annotations. Only the
+        upload itself is left to the caller, which is what differs between
+        synchronous and asynchronous pushes.
+
+        :param files: the files to push
+        :type files: list
+        :param annotset: annotations to apply to blobs
+        :type annotset: oras.oci.Annotations
+        :param disable_path_validation: allow paths outside the working directory
+        :type disable_path_validation: bool
+        :return: a generator of (blob path, layer, whether the blob is temporary)
+        """
+        for blob in files:
+            # You can provide a blob + content type
+            path_content: PathAndOptionalContent = oras.utils.split_path_and_content(
+                str(blob)
+            )
+            blob = path_content.path
+            media_type = path_content.content
+
+            # Must exist
+            if not os.path.exists(blob):
+                raise FileNotFoundError(f"{blob} does not exist.")
+
+            # Path validation means blob must be relative to PWD.
+            if not disable_path_validation:
+                if not self._validate_path(blob):
+                    raise ValueError(
+                        f"Blob {blob} is not in the present working directory context."
+                    )
+
+            # Save directory or blob name before compressing
+            blob_name = os.path.basename(blob)
+
+            # If it's a directory, we need to compress
+            cleanup_blob = False
+            if os.path.isdir(blob):
+                blob = oras.utils.make_targz(blob)
+                cleanup_blob = True
+
+            # Create a new layer from the blob
+            layer = oras.oci.NewLayer(blob, is_dir=cleanup_blob, media_type=media_type)
+            annotations = annotset.get_annotations(blob)
+
+            # Always strip blob_name of path separator
+            layer["annotations"] = {
+                oras.defaults.annotation_title: blob_name.strip(os.sep)
+            }
+            if annotations:
+                layer["annotations"].update(annotations)
+
+            logger.debug(f"Preparing layer {layer}")
+            yield blob, layer, cleanup_blob
+
+    def _apply_manifest_annotations(
+        self,
+        manifest: dict,
+        annotset: oras.oci.Annotations,
+        manifest_annotations: Optional[dict],
+        subject: Optional[str],
+    ):
+        """
+        Add annotations and a subject to a manifest, if there are any.
+
+        :param manifest: the manifest to update
+        :type manifest: dict
+        :param annotset: annotations parsed from a file
+        :type annotset: oras.oci.Annotations
+        :param manifest_annotations: annotations given by the caller, which win
+        :type manifest_annotations: dict
+        :param subject: optional subject reference
+        :type subject: oras.oci.Subject
+        """
+        manifest_annots = annotset.get_annotations("$manifest") or {}
+
+        # Custom manifest annotations from client key=value pairs
+        # These over-ride any potentially provided from file
+        custom_annots = copy.deepcopy(manifest_annotations)
+        if custom_annots:
+            manifest_annots.update(custom_annots)
+        if manifest_annots:
+            manifest["annotations"] = manifest_annots
+
+        if subject:
+            manifest["subject"] = asdict(subject)
+
+    def _prepare_manifest_config(
+        self, manifest_config: Optional[str], annotset: oras.oci.Annotations
+    ) -> Tuple[dict, Optional[str]]:
+        """
+        Build the manifest config, from a provided one or an empty one.
+
+        :param manifest_config: path and optional media type of a config to use
+        :type manifest_config: str
+        :param annotset: annotations to apply to the config
+        :type annotset: oras.oci.Annotations
+        :return: the config layer, and the file to upload for it if there is one
+        """
+        config_annots = annotset.get_annotations("$config")
+        if manifest_config:
+            ref, media_type = self._parse_manifest_ref(manifest_config)
+            conf, config_file = oras.oci.ManifestConfig(ref, media_type)
+        else:
+            conf, config_file = oras.oci.ManifestConfig()
+
+        # Config annotations?
+        if config_annots:
+            conf["annotations"] = config_annots
+
+        logger.debug(f"Preparing config {conf}")
+        return conf, config_file
+
+    def _iter_pull_targets(
+        self, manifest: dict, outdir: str, overwrite: bool
+    ) -> Generator[Tuple[dict, str], None, None]:
+        """
+        Work out where each layer of a manifest should be written.
+
+        Resolving the output name, guarding against a malicious path and
+        honouring overwrite are all decisions, so they live here and a pull
+        only has to download what is yielded.
+
+        :param manifest: the manifest being pulled
+        :type manifest: dict
+        :param outdir: directory to write to
+        :type outdir: str
+        :param overwrite: overwrite an existing file
+        :type overwrite: bool
+        :return: a generator of (layer, output path)
+        """
+        for layer in manifest.get("layers", []):
+            filename = (layer.get("annotations") or {}).get(
+                oras.defaults.annotation_title
+            )
+
+            # If we don't have a filename, default to digest. Hopefully does not happen
+            if not filename:
+                filename = layer["digest"]
+
+            # This raises an error if there is a malicious path
+            outfile = oras.utils.sanitize_path(outdir, os.path.join(outdir, filename))
+
+            if not overwrite and os.path.exists(outfile):
+                logger.warning(
+                    f"{outfile} already exists and --keep-old-files set, will not overwrite."
+                )
+                continue
+
+            yield layer, outfile
+
+
+class Registry(RegistryBase):
+    """
+    Direct interactions with an OCI registry.
+
+    This could also be called a "provider" when we add in the "copy" logic
+    and the registry isn't necessarily the "remote" endpoint.
+    """
+
+    def __init__(
+        self,
+        hostname: Optional[str] = None,
+        insecure: bool = False,
+        tls_verify: Union[bool, str] = True,
+        auth_backend: str = "token",
+        transport: Optional[Transport] = None,
+    ):
+        """
+        Create an ORAS client.
+
+        The hostname is the remote registry to ping.
+
+        :param hostname: the hostname of the registry to ping
+        :type hostname: str
+        :param insecure: use http instead of https
+        :type insecure: bool
+        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+        :type tls_verify: bool
+        :param auth_backend: name of the auth backend to use
+        :type auth_backend: str
+        :param transport: how to send requests, defaults to a new transport
+                          configured with tls_verify. A provided transport is
+                          used as given, so it carries its own tls settings
+        :type transport: oras.transport.Transport
+        """
+        super().__init__(
+            transport=transport or Transport(tls_verify=tls_verify),
+            hostname=hostname,
+            insecure=insecure,
+            auth_backend=auth_backend,
+        )
+
+    @property
+    def session(self) -> requests.Session:
+        """
+        The session used to interact with the registry.
+        """
+        return self.transport.session
+
+    @session.setter
+    def session(self, session: requests.Session):
+        self.transport.session = session
+
+    @property
+    def _tls_verify(self) -> Union[bool, str]:
+        """
+        Whether tls verification is enabled, or the custom CA-Bundle in use.
+        """
+        return self.transport.tls_verify
+
+    @_tls_verify.setter
+    def _tls_verify(self, tls_verify: Union[bool, str]):
+        self.transport.tls_verify = tls_verify
+
+    def close(self):
+        """
+        Release the connections held by the transport.
+
+        Calling this is optional, and a client is not required to be used as a
+        context manager. It is here for callers that create many clients and
+        want the pooled connections closed promptly.
+        """
+        self.transport.close()
+
+    def delete_tags(self, name: str, tags=Union[str, list]) -> List[str]:
+        """
+        Delete one or more tags for a unique resource identifier.
+
+        Returns those successfully deleted.
+
+        :param name: container URI to parse
+        :type name: str
+        :param tags: single or multiple tags name to delete
+        :type N: string or list
+        """
+        if isinstance(tags, str):
+            tags = [tags]
+        deleted = []
+        for tag in tags:
+            if self.delete_tag(name, tag):
+                deleted.append(tag)
+        return deleted
 
     def upload_blob(
         self,
@@ -465,17 +743,6 @@ class Registry:
         blob_url = self._url(container.get_blob_url(digest))  # type: ignore
         return self.do_request(blob_url, method, headers=self.headers, stream=stream)
 
-    def get_container(self, name: container_type) -> oras.container.Container:
-        """
-        Courtesy function to get a container from a URI.
-
-        :param name: unique resource identifier to parse
-        :type name: oras.container.Container or str
-        """
-        if isinstance(name, oras.container.Container):
-            return name
-        return oras.container.Container(name, registry=self.hostname)
-
     # Functions to be deprecated in favor of exposed ones
     @decorator.ensure_container
     def _download_blob(
@@ -605,48 +872,6 @@ class Registry:
         response = self.do_request(self._url(blob_url), "HEAD")
         return response.status_code == 200
 
-    def _get_location(
-        self, r: requests.Response, container: oras.container.Container
-    ) -> str:
-        """
-        Parse the location header and ensure it includes a hostname.
-        This currently assumes if there isn't a hostname, we are pushing to
-        the same registry hostname of the original request.
-
-        :param r: requests response with headers
-        :type r: requests.Response
-        :param container:  parsed container URI
-        :type container: oras.container.Container or str
-        """
-        session_url = r.headers.get("location", "")
-        if not session_url:
-            return session_url
-
-        # Some registries do not return the full registry hostname.  Check that
-        # the url starts with a protocol scheme, change tracked with:
-        # https://github.com/oras-project/oras-py/issues/78
-        prefix = f"{self.prefix}://{container.registry}"
-
-        if not session_url.startswith("http"):
-            session_url = f"{prefix}{session_url}"
-        return session_url
-
-    def _require_location(
-        self, r: requests.Response, container: oras.container.Container
-    ) -> str:
-        """
-        Parse the location header, and require that one was provided.
-
-        :param r: requests response with headers
-        :type r: requests.Response
-        :param container:  parsed container URI
-        :type container: oras.container.Container
-        """
-        session_url = self._get_location(r, container)
-        if not session_url:
-            raise ValueError(f"Issue retrieving session url: {r.json()}")
-        return session_url
-
     def _start_upload_session(
         self, container: oras.container.Container, headers: dict
     ) -> str:
@@ -716,32 +941,6 @@ class Registry:
             session_url, {"digest": layer["digest"]}
         )
         return self.do_request(session_url, "PUT", headers=self.headers)
-
-    def _check_200_response(self, response: requests.Response):
-        """
-        Helper function to ensure some flavor of 200
-
-        :param response: request response to inspect
-        :type response: requests.Response
-        """
-        if response.status_code not in [200, 201, 202]:
-            self._parse_response_errors(response)
-            raise ValueError(f"Issue with {response.request.url}: {response.reason}")
-
-    def _parse_response_errors(self, response: requests.Response):
-        """
-        Given a failed request, look for OCI formatted error messages.
-
-        :param response: request response to inspect
-        :type response: requests.Response
-        """
-        try:
-            msg = response.json()
-            for error in msg.get("errors", []):
-                if isinstance(error, dict) and "message" in error:
-                    logger.error(error["message"])
-        except Exception:
-            pass
 
     def upload_manifest(
         self,
@@ -850,51 +1049,13 @@ class Registry:
 
         # A lookup of annotations we can add (to blobs or manifest)
         annotset = oras.oci.Annotations(annotation_file)
-        media_type = None
 
         # Upload files as blobs
-        for blob in files:
-            # You can provide a blob + content type
-            path_content: PathAndOptionalContent = oras.utils.split_path_and_content(
-                str(blob)
-            )
-            blob = path_content.path
-            media_type = path_content.content
-
-            # Must exist
-            if not os.path.exists(blob):
-                raise FileNotFoundError(f"{blob} does not exist.")
-
-            # Path validation means blob must be relative to PWD.
-            if not disable_path_validation:
-                if not self._validate_path(blob):
-                    raise ValueError(
-                        f"Blob {blob} is not in the present working directory context."
-                    )
-
-            # Save directory or blob name before compressing
-            blob_name = os.path.basename(blob)
-
-            # If it's a directory, we need to compress
-            cleanup_blob = False
-            if os.path.isdir(blob):
-                blob = oras.utils.make_targz(blob)
-                cleanup_blob = True
-
-            # Create a new layer from the blob
-            layer = oras.oci.NewLayer(blob, is_dir=cleanup_blob, media_type=media_type)
-            annotations = annotset.get_annotations(blob)
-
-            # Always strip blob_name of path separator
-            layer["annotations"] = {
-                oras.defaults.annotation_title: blob_name.strip(os.sep)
-            }
-            if annotations:
-                layer["annotations"].update(annotations)
-
+        for blob, layer, cleanup_blob in self._iter_push_layers(
+            files, annotset, disable_path_validation
+        ):
             # update the manifest with the new layer
             manifest["layers"].append(layer)
-            logger.debug(f"Preparing layer {layer}")
 
             # Upload the blob layer
             response = self.upload_blob(
@@ -910,34 +1071,12 @@ class Registry:
             if cleanup_blob and os.path.exists(blob):
                 os.remove(blob)
 
-        # Add annotations to the manifest, if provided
-        manifest_annots = annotset.get_annotations("$manifest") or {}
-
-        # Custom manifest annotations from client key=value pairs
-        # These over-ride any potentially provided from file
-        custom_annots = copy.deepcopy(manifest_annotations)
-        if custom_annots:
-            manifest_annots.update(custom_annots)
-        if manifest_annots:
-            manifest["annotations"] = manifest_annots
-
-        if subject:
-            manifest["subject"] = asdict(subject)
-
-        # Prepare the manifest config (temporary or one provided)
-        config_annots = annotset.get_annotations("$config")
-        if manifest_config:
-            ref, media_type = self._parse_manifest_ref(manifest_config)
-            conf, config_file = oras.oci.ManifestConfig(ref, media_type)
-        else:
-            conf, config_file = oras.oci.ManifestConfig()
-
-        # Config annotations?
-        if config_annots:
-            conf["annotations"] = config_annots
+        self._apply_manifest_annotations(
+            manifest, annotset, manifest_annotations, subject
+        )
+        conf, config_file = self._prepare_manifest_config(manifest_config, annotset)
 
         # Config is just another layer blob!
-        logger.debug(f"Preparing config {conf}")
         with (
             temporary_empty_config()
             if config_file is None
@@ -990,24 +1129,7 @@ class Registry:
         overwrite = overwrite
 
         files = []
-        for layer in manifest.get("layers", []):
-            filename = (layer.get("annotations") or {}).get(
-                oras.defaults.annotation_title
-            )
-
-            # If we don't have a filename, default to digest. Hopefully does not happen
-            if not filename:
-                filename = layer["digest"]
-
-            # This raises an error if there is a malicious path
-            outfile = oras.utils.sanitize_path(outdir, os.path.join(outdir, filename))
-
-            if not overwrite and os.path.exists(outfile):
-                logger.warning(
-                    f"{outfile} already exists and --keep-old-files set, will not overwrite."
-                )
-                continue
-
+        for layer, outfile in self._iter_pull_targets(manifest, outdir, overwrite):
             # A directory will need to be uncompressed and moved
             if layer["mediaType"] == oras.defaults.default_blob_dir_media_type:
                 targz = oras.utils.get_tmpfile(suffix=".tar.gz")

--- a/oras/provider_async.py
+++ b/oras/provider_async.py
@@ -109,7 +109,9 @@ class AsyncRegistry(RegistryBase):
         :type url: str
         :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
         :type method: str
-        :param data: body for the request
+        :param data: body for the request. A body that can only be read
+                     once must be given as a callable returning a fresh
+                     one, since the request may be sent again
         :param headers: headers for the request
         :type headers: dict
         :param json: json data for the request
@@ -124,7 +126,12 @@ class AsyncRegistry(RegistryBase):
         if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
             headers.update(self.auth.get_auth_header())
         response = await self.transport.request(
-            url, method, data=data, headers=headers, json=json, params=params
+            url,
+            method,
+            data=self._request_body(data),
+            headers=headers,
+            json=json,
+            params=params,
         )
 
         # A 401 response is a request for authentication, 404 is not found
@@ -135,7 +142,12 @@ class AsyncRegistry(RegistryBase):
         if not changed:
             raise ValueError("Cannot respond to request for authentication.")
         response = await self.transport.request(
-            url, method, data=data, headers=headers, json=json, params=params
+            url,
+            method,
+            data=self._request_body(data),
+            headers=headers,
+            json=json,
+            params=params,
         )
 
         # One retry if 403 denied (need new token?)
@@ -144,7 +156,12 @@ class AsyncRegistry(RegistryBase):
                 response, headers, refresh=True
             )
             response = await self.transport.request(
-                url, method, data=data, headers=headers, json=json, params=params
+                url,
+                method,
+                data=self._request_body(data),
+                headers=headers,
+                json=json,
+                params=params,
             )
 
         return response
@@ -343,11 +360,14 @@ class AsyncRegistry(RegistryBase):
         )
 
         # An iterator keeps the blob out of memory. Content-Length is set from
-        # the layer, so the registry still gets a sized request.
+        # the layer, so the registry still gets a sized request. It is passed
+        # as a callable because an iterator is spent once it has been read, and
+        # this request is re-sent to answer an authentication challenge or by
+        # the retry decorator - each attempt needs to read the file again.
         return await self.do_request(
             blob_url,
             method="PUT",
-            data=iter_file(blob, oras.defaults.default_blocksize),
+            data=lambda: iter_file(blob, oras.defaults.default_blocksize),
             headers=headers,
         )
 

--- a/oras/provider_async.py
+++ b/oras/provider_async.py
@@ -1,0 +1,684 @@
+"""
+Asynchronous interactions with an OCI registry.
+
+:class:`AsyncRegistry` is the asynchronous counterpart to
+:class:`oras.provider.Registry`. Both derive from
+:class:`oras.provider.RegistryBase`, which holds everything that is a decision
+rather than a call: url construction, reference handling, preparing layers from
+files, resolving output paths, and interpreting responses.
+
+What is written here is the orchestration that has to await, and only that. A
+change to what a push does belongs in RegistryBase and is picked up by both;
+a change to how a request is carried out belongs in a transport.
+"""
+
+__copyright__ = "Copyright The ORAS Authors."
+__license__ = "Apache-2.0"
+
+import os
+import urllib
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
+
+import jsonschema
+
+import oras.auth
+import oras.decorator as decorator
+import oras.defaults
+import oras.oci
+import oras.schemas
+import oras.utils
+from oras.logger import logger
+from oras.provider import RegistryBase, temporary_empty_config
+from oras.transport_async import AsyncTransport, get_httpx, iter_file
+from oras.types import container_type
+
+if TYPE_CHECKING:
+    import httpx
+
+
+class AsyncRegistry(RegistryBase):
+    """
+    Asynchronous interactions with an OCI registry.
+
+    The client owns an httpx connection pool for its lifetime, so it should be
+    closed when finished, either with `async with` or by awaiting aclose().
+    """
+
+    def __init__(
+        self,
+        hostname: Optional[str] = None,
+        insecure: bool = False,
+        tls_verify=True,
+        auth_backend: str = "token",
+        transport: Optional[AsyncTransport] = None,
+    ):
+        """
+        Create an asynchronous ORAS client.
+
+        :param hostname: the hostname of the registry to ping
+        :type hostname: str
+        :param insecure: use http instead of https
+        :type insecure: bool
+        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+        :type tls_verify: bool or str
+        :param auth_backend: name of the auth backend to use
+        :type auth_backend: str
+        :param transport: how to send requests, defaults to a new async
+                          transport configured with tls_verify
+        :type transport: oras.transport_async.AsyncTransport
+        """
+        super().__init__(
+            transport=transport or AsyncTransport(tls_verify=tls_verify),
+            hostname=hostname,
+            insecure=insecure,
+            auth_backend=auth_backend,
+        )
+
+    async def __aenter__(self) -> "AsyncRegistry":
+        return self
+
+    async def __aexit__(self, *args):
+        await self.aclose()
+
+    async def aclose(self):
+        """
+        Close the underlying client and release its connections.
+        """
+        await self.transport.aclose()
+
+    @decorator.retry_async()
+    async def do_request(
+        self,
+        url: str,
+        method: str = "GET",
+        data=None,
+        headers: Optional[dict] = None,
+        json: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ) -> "httpx.Response":
+        """
+        Do a request, answering an authentication challenge if there is one.
+
+        This mirrors the synchronous Registry.do_request: try, and on a 401 or
+        403 ask the auth backend to answer the challenge and try once more,
+        with one further attempt after a second 403 in case the token needs
+        refreshing. The answer is awaited, so no part of it blocks the loop.
+
+        :param url: the URL to issue the request to
+        :type url: str
+        :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
+        :type method: str
+        :param data: body for the request
+        :param headers: headers for the request
+        :type headers: dict
+        :param json: json data for the request
+        :type json: dict
+        :param params: query string parameters to add to the url
+        :type params: dict
+        """
+        if headers is None:
+            headers = {}
+
+        # Use a token we already hold, as the sync provider does
+        if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
+            headers.update(self.auth.get_auth_header())
+        response = await self.transport.request(
+            url, method, data=data, headers=headers, json=json, params=params
+        )
+
+        # A 401 response is a request for authentication, 404 is not found
+        if response.status_code not in [401, 403]:
+            return response
+
+        headers, changed = await self.auth.authenticate_request_async(response, headers)
+        if not changed:
+            raise ValueError("Cannot respond to request for authentication.")
+        response = await self.transport.request(
+            url, method, data=data, headers=headers, json=json, params=params
+        )
+
+        # One retry if 403 denied (need new token?)
+        if response.status_code == 403:
+            headers, changed = await self.auth.authenticate_request_async(
+                response, headers, refresh=True
+            )
+            response = await self.transport.request(
+                url, method, data=data, headers=headers, json=json, params=params
+            )
+
+        return response
+
+    async def _do_paginated_request(
+        self, url: str, callable: Callable[["httpx.Response"], bool]
+    ):
+        """
+        Paginate a request for a URL.
+
+        We look for the "Link" header to get the next URL to ping. If
+        the callable returns True, we continue to the next page, otherwise
+        we stop.
+        """
+        parts = urllib.parse.urlparse(url)
+        base_url = f"{parts.scheme}://{parts.netloc}"
+
+        while True:
+            response = await self.do_request(url, "GET", headers=self.headers)
+            self._check_200_response(response)
+
+            if not callable(response):
+                break
+
+            link = response.links.get("next", {}).get("url")
+            if not link:
+                break
+
+            url = urllib.parse.urljoin(base_url, link)
+
+    @decorator.ensure_container
+    async def get_tags(self, container: container_type, N=None) -> List[str]:
+        """
+        Retrieve tags for a package.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param N: limit number of tags, None for all (default)
+        :type N: Optional[int]
+        """
+        retrieve_all = N is None
+        tags_url = self._url(container.tags_url(N=N))  # type: ignore
+        tags: List[str] = []
+
+        def extract_tags(response) -> bool:
+            json = response.json()
+            new_tags = json.get("tags") or []
+            tags.extend(new_tags)
+            return bool(len(new_tags) and (retrieve_all or len(tags) < N))
+
+        await self._do_paginated_request(tags_url, callable=extract_tags)
+
+        if N is not None and len(tags) > N:
+            tags = tags[:N]
+        return tags
+
+    @decorator.ensure_container
+    async def delete_tag(self, container: container_type, tag: str) -> bool:
+        """
+        Delete a tag for a container.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param tag: name of tag to delete
+        :type tag: str
+        """
+        logger.debug(f"Deleting tag {tag} for {container}")
+
+        head_url = self._url(container.manifest_url(tag))  # type: ignore
+        response = await self.do_request(
+            head_url,
+            "HEAD",
+            headers={"Accept": oras.defaults.default_manifest_media_type},
+        )
+        if response.status_code == 404:
+            logger.error(f"Cannot find tag {container}:{tag}")
+            return False
+
+        digest = response.headers.get("Docker-Content-Digest")
+        if not digest:
+            raise RuntimeError("Expected to find Docker-Content-Digest header.")
+
+        delete_url = self._url(container.manifest_url(digest))  # type: ignore
+        response = await self.do_request(delete_url, "DELETE")
+        if response.status_code != 202:
+            raise RuntimeError(f"Delete was not successful: {response.json()}")
+        return True
+
+    async def delete_tags(self, name: str, tags) -> List[str]:
+        """
+        Delete one or more tags, returning those successfully deleted.
+
+        :param name: container URI to parse
+        :type name: str
+        :param tags: single or multiple tags name to delete
+        :type tags: string or list
+        """
+        if isinstance(tags, str):
+            tags = [tags]
+        deleted = []
+        for tag in tags:
+            if await self.delete_tag(name, tag):
+                deleted.append(tag)
+        return deleted
+
+    async def blob_exists(self, layer: dict, container) -> bool:
+        """
+        Check if a layer already exists in the registry.
+
+        :param layer: the layer to check for existence
+        :type layer: dict
+        :param container: where to look for the layer
+        :type container: oras.container.Container
+        """
+        blob_url = container.get_blob_url(layer["digest"])
+        response = await self.do_request(self._url(blob_url), "HEAD")
+        return response.status_code == 200
+
+    @decorator.ensure_container
+    async def download_blob(
+        self, container: container_type, digest: str, outfile: str
+    ) -> str:
+        """
+        Stream a blob to a file, without holding it in memory.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param digest: sha256 digest of the blob to retrieve
+        :type digest: str
+        :param outfile: file to write the blob to
+        :type outfile: str
+        """
+        httpx_module = get_httpx()
+        try:
+            outdir = os.path.dirname(outfile)
+            if outdir and not os.path.exists(outdir):
+                oras.utils.mkdir_p(outdir)
+
+            blob_url = self._url(container.get_blob_url(digest))  # type: ignore
+            headers = dict(self.headers)
+            if (
+                isinstance(self.auth, oras.auth.TokenAuth)
+                and self.auth.token is not None
+            ):
+                headers.update(self.auth.get_auth_header())
+
+            async with self.transport.stream(blob_url, "GET", headers=headers) as r:
+                r.raise_for_status()
+                with open(outfile, "wb") as f:
+                    async for chunk in r.aiter_bytes(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+
+        # Allow an empty layer to fail and return /dev/null
+        except (httpx_module.HTTPError, OSError) as e:
+            if digest == oras.defaults.blank_hash:
+                return os.devnull
+            raise e
+        return outfile
+
+    async def _start_upload_session(self, container, headers: dict) -> str:
+        """
+        Open a blob upload session and return the url to upload to.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param headers: headers to start the session with
+        :type headers: dict
+        """
+        upload_url = self._url(container.upload_blob_url())
+        r = await self.do_request(upload_url, "POST", headers=headers)
+        return self._require_location(r, container)
+
+    async def put_upload(self, blob: str, container, layer: dict) -> "httpx.Response":
+        """
+        Upload a blob in one request, streamed from disk.
+
+        :param blob: path to blob to upload
+        :type blob: str
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param layer: dict from oras.oci.NewLayer
+        :type layer: dict
+        """
+        session_url = await self._start_upload_session(
+            container, {"Content-Type": "application/octet-stream"}
+        )
+
+        headers = {
+            "Content-Length": str(layer["size"]),
+            "Content-Type": "application/octet-stream",
+        }
+        headers.update(self.headers)
+        blob_url = oras.utils.append_url_params(
+            session_url, {"digest": layer["digest"]}
+        )
+
+        # An iterator keeps the blob out of memory. Content-Length is set from
+        # the layer, so the registry still gets a sized request.
+        return await self.do_request(
+            blob_url,
+            method="PUT",
+            data=iter_file(blob, oras.defaults.default_blocksize),
+            headers=headers,
+        )
+
+    async def chunked_upload(
+        self,
+        blob: str,
+        container,
+        layer: dict,
+        chunk_size: int = oras.defaults.default_chunksize,
+    ) -> "httpx.Response":
+        """
+        Upload a blob as a series of chunks.
+
+        Same sequence as the synchronous provider: POST to open a session,
+        PATCH each chunk with its content range, then PUT with the digest to
+        close it.
+
+        :param blob: path to blob to upload
+        :type blob: str
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param layer: dict from oras.oci.NewLayer
+        :type layer: dict
+        :param chunk_size: chunk size in bytes
+        :type chunk_size: int
+        """
+        headers = {"Content-Type": "application/octet-stream", "Content-Length": "0"}
+        headers.update(self.headers)
+        session_url = await self._start_upload_session(container, headers)
+
+        start = 0
+        with open(blob, "rb") as fd:
+            for chunk in oras.utils.read_in_chunks(fd, chunk_size=chunk_size):
+                end = start + len(chunk) - 1
+                content_range = "%s-%s" % (start, end)
+                headers = {
+                    "Content-Range": content_range,
+                    "Content-Length": str(len(chunk)),
+                    "Content-Type": "application/octet-stream",
+                }
+                headers.update(self.headers)
+
+                start = end + 1
+                r = await self.do_request(
+                    session_url, "PATCH", data=chunk, headers=headers
+                )
+                self._check_200_response(r)
+                session_url = self._require_location(r, container)
+
+        session_url = oras.utils.append_url_params(
+            session_url, {"digest": layer["digest"]}
+        )
+        return await self.do_request(session_url, "PUT", headers=self.headers)
+
+    async def upload_blob(
+        self,
+        blob: str,
+        container: container_type,
+        layer: dict,
+        do_chunked: bool = False,
+        chunk_size: int = oras.defaults.default_chunksize,
+    ) -> "httpx.Response":
+        """
+        Prepare and upload a blob.
+
+        :param blob: path to blob to upload
+        :type blob: str
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param layer: dict from oras.oci.NewLayer
+        :type layer: dict
+        :param do_chunked: if true do chunked blob upload
+        :type do_chunked: bool
+        :param chunk_size: chunk size in bytes
+        :type chunk_size: int
+        """
+        httpx_module = get_httpx()
+        blob = os.path.abspath(blob)
+        container = self.get_container(container)
+
+        if await self.blob_exists(layer, container):
+            logger.debug(f'layer already exists: {layer["digest"]}')
+            return httpx_module.Response(200)
+
+        if not do_chunked:
+            response = await self.put_upload(blob, container, layer)
+        else:
+            response = await self.chunked_upload(
+                blob, container, layer, chunk_size=chunk_size
+            )
+
+        # An empty layer the registry would not take is still a success
+        if (
+            response.status_code not in [200, 201, 202]
+            and layer["digest"] == oras.defaults.blank_hash
+        ):
+            response = httpx_module.Response(200)
+        return response
+
+    async def upload_manifest(self, manifest: dict, container) -> "httpx.Response":
+        """
+        Read a manifest file and upload it.
+
+        :param manifest: manifest to upload
+        :type manifest: dict
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        """
+        jsonschema.validate(manifest, schema=oras.schemas.manifest)
+        headers = {"Content-Type": oras.defaults.default_manifest_media_type}
+        return await self.do_request(
+            self._url(container.manifest_url()),
+            "PUT",
+            headers=headers,
+            json=manifest,
+        )
+
+    async def upload_manifest_content(
+        self,
+        content: bytes,
+        container,
+        media_type: str,
+        reference: Optional[str] = None,
+    ) -> "httpx.Response":
+        """
+        Upload a manifest from the exact bytes it should be stored as.
+
+        :param content: the raw manifest (or index) bytes to upload
+        :type content: bytes
+        :param container:  parsed container URI
+        :type container: oras.container.Container
+        :param media_type: media type of the manifest, used as the Content-Type
+        :type media_type: str
+        :param reference: tag or digest to upload to, defaults to the container reference
+        :type reference: str
+        """
+        headers = {"Content-Type": media_type}
+        return await self.do_request(
+            self._url(container.manifest_url(reference)),
+            "PUT",
+            headers=headers,
+            data=content,
+        )
+
+    @decorator.ensure_container
+    async def get_manifest_content(
+        self,
+        container: container_type,
+        allowed_media_type: Optional[list] = None,
+        reference: Optional[str] = None,
+    ) -> Tuple[bytes, Optional[str]]:
+        """
+        Retrieve a manifest as the raw bytes the registry served, with its digest.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param allowed_media_type: one or more allowed media types
+        :type allowed_media_type: list
+        :param reference: tag or digest to retrieve, defaults to the container reference
+        :type reference: str
+        :return: tuple of the raw manifest bytes, and the digest reported by the
+                 registry in the Docker-Content-Digest header (None if absent)
+        """
+        if not allowed_media_type:
+            allowed_media_type = oras.defaults.default_manifest_accepted_media_types
+        headers = {"Accept": ", ".join(allowed_media_type)}
+
+        manifest_url = self._url(container.manifest_url(reference))  # type: ignore
+        response = await self.do_request(manifest_url, "GET", headers=headers)
+
+        self._check_200_response(response)
+        return response.content, response.headers.get("Docker-Content-Digest")
+
+    @decorator.ensure_container
+    async def get_manifest(
+        self,
+        container: container_type,
+        allowed_media_type: Optional[list] = None,
+        validation_schema: Optional[dict] = None,
+    ) -> dict:
+        """
+        Retrieve a manifest for a package.
+
+        :param container:  parsed container URI
+        :type container: oras.container.Container or str
+        :param allowed_media_type: one or more allowed media types
+        :type allowed_media_type: str
+        :param validation_schema: optional json schema to validate the manifest against
+        :type validation_schema: dict
+        """
+        self.auth.load_configs(container)
+
+        if not allowed_media_type:
+            allowed_media_type = oras.defaults.default_manifest_accepted_media_types
+        headers = {"Accept": ", ".join(allowed_media_type)}
+
+        get_manifest = self._url(container.manifest_url())  # type: ignore
+        response = await self.do_request(get_manifest, "GET", headers=headers)
+
+        self._check_200_response(response)
+        manifest = response.json()
+        if validation_schema:
+            jsonschema.validate(manifest, schema=validation_schema)
+        return manifest
+
+    async def push(
+        self,
+        target: str,
+        config_path: Optional[str] = None,
+        disable_path_validation: bool = False,
+        files: Optional[List] = None,
+        manifest_config: Optional[str] = None,
+        annotation_file: Optional[str] = None,
+        manifest_annotations: Optional[dict] = None,
+        subject: Optional[str] = None,
+        do_chunked: bool = False,
+        chunk_size: int = oras.defaults.default_chunksize,
+        quiet: bool = False,
+    ) -> "httpx.Response":
+        """
+        Push a set of files to a target.
+
+        What to push and how to describe it is decided by RegistryBase, so this
+        is only the uploading.
+
+        :param target: target location to push to
+        :type target: str
+        :param config_path: path to a config file
+        :type config_path: str
+        :param disable_path_validation: ensure paths are relative to the running directory.
+        :type disable_path_validation: bool
+        :param files: list of files to push
+        :type files: list
+        :param annotation_file: manifest annotations file
+        :type annotation_file: str
+        :param manifest_annotations: manifest annotations
+        :type manifest_annotations: dict
+        :param do_chunked: if true do chunked blob upload
+        :type do_chunked: bool
+        :param chunk_size: chunk size in bytes
+        :type chunk_size: int
+        :param subject: optional subject reference
+        :type subject: oras.oci.Subject
+        :param quiet: suppress the completion message
+        :type quiet: bool
+        """
+        container = self.get_container(target)
+        files = files or []
+        self.auth.load_configs(
+            container, configs=[config_path] if config_path else None
+        )
+
+        manifest = oras.oci.NewManifest()
+        annotset = oras.oci.Annotations(annotation_file)
+
+        for blob, layer, cleanup_blob in self._iter_push_layers(
+            files, annotset, disable_path_validation
+        ):
+            manifest["layers"].append(layer)
+
+            response = await self.upload_blob(
+                blob, container, layer, do_chunked=do_chunked, chunk_size=chunk_size
+            )
+            self._check_200_response(response)
+
+            if cleanup_blob and os.path.exists(blob):
+                os.remove(blob)
+
+        self._apply_manifest_annotations(
+            manifest, annotset, manifest_annotations, subject
+        )
+        conf, config_file = self._prepare_manifest_config(manifest_config, annotset)
+
+        with (
+            temporary_empty_config()
+            if config_file is None
+            else nullcontext(config_file)
+        ) as config_file:
+            response = await self.upload_blob(config_file, container, conf)
+
+        self._check_200_response(response)
+
+        manifest["config"] = conf
+        response = await self.upload_manifest(manifest, container)
+        self._check_200_response(response)
+        if not quiet:
+            logger.info(f"Successfully pushed {container}")
+        return response
+
+    async def pull(
+        self,
+        target: str,
+        config_path: Optional[str] = None,
+        allowed_media_type: Optional[List] = None,
+        overwrite: bool = True,
+        outdir: Optional[str] = None,
+    ) -> List[str]:
+        """
+        Pull an artifact from a target.
+
+        Where each layer is written is decided by RegistryBase, so this is only
+        the downloading.
+
+        :param target: target location to pull from
+        :type target: str
+        :param config_path: path to a config file
+        :type config_path: str
+        :param allowed_media_type: list of allowed media types
+        :type allowed_media_type: list or None
+        :param overwrite: if output file exists, overwrite
+        :type overwrite: bool
+        :param outdir: output directory path
+        :type outdir: str
+        """
+        container = self.get_container(target)
+        self.auth.load_configs(
+            container, configs=[config_path] if config_path else None
+        )
+        manifest = await self.get_manifest(container, allowed_media_type)
+        outdir = outdir or oras.utils.get_tmpdir()
+
+        files = []
+        for layer, outfile in self._iter_pull_targets(manifest, outdir, overwrite):
+            # A directory will need to be uncompressed and moved
+            if layer["mediaType"] == oras.defaults.default_blob_dir_media_type:
+                targz = oras.utils.get_tmpfile(suffix=".tar.gz")
+                await self.download_blob(container, layer["digest"], targz)
+                oras.utils.extract_targz(targz, os.path.dirname(outfile))
+            else:
+                await self.download_blob(container, layer["digest"], outfile)
+
+            logger.info(f"Successfully pulled {outfile}.")
+            files.append(outfile)
+        return files

--- a/oras/provider_async.py
+++ b/oras/provider_async.py
@@ -15,9 +15,10 @@ a change to how a request is carried out belongs in a transport.
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+import asyncio
 import os
 import urllib
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import jsonschema
@@ -35,6 +36,11 @@ from oras.types import container_type
 
 if TYPE_CHECKING:
     import httpx
+
+# A download streams rather than going through do_request, so it carries the
+# same retry policy here instead of inheriting the decorator's.
+DOWNLOAD_ATTEMPTS = 5
+DOWNLOAD_TIMEOUT = 2
 
 
 class AsyncRegistry(RegistryBase):
@@ -166,6 +172,70 @@ class AsyncRegistry(RegistryBase):
 
         return response
 
+    @asynccontextmanager
+    async def stream_request(
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ):
+        """
+        Send a request and yield the response with its body still unread.
+
+        This is the streaming counterpart to do_request, and answers an
+        authentication challenge the same way: once, then once more with a
+        refreshed token if the retry is still refused. do_request itself
+        cannot be used here because it returns a response whose body has
+        already been read, which is the thing a download must avoid.
+
+        :param url: the URL to issue the request to
+        :type url: str
+        :param method: the method to use
+        :type method: str
+        :param headers: headers for the request
+        :type headers: dict
+        :param params: query string parameters to add to the url
+        :type params: dict
+        """
+        headers = dict(headers or {})
+        if isinstance(self.auth, oras.auth.TokenAuth) and self.auth.token is not None:
+            headers.update(self.auth.get_auth_header())
+
+        async def open_stream(request_headers):
+            stream = self.transport.stream(
+                url, method, headers=request_headers, params=params
+            )
+            return stream, await stream.__aenter__()
+
+        stream, response = await open_stream(headers)
+        try:
+            # The challenge is in the headers, so it can be read without
+            # touching the body; the stream is closed and opened again rather
+            # than replayed.
+            if response.status_code in [401, 403]:
+                headers, changed = await self.auth.authenticate_request_async(
+                    response, headers
+                )
+                if not changed:
+                    raise ValueError("Cannot respond to request for authentication.")
+                await stream.__aexit__(None, None, None)
+                stream, response = await open_stream(headers)
+
+                # One retry if 403 denied (need new token?). As in do_request,
+                # the refreshed answer is tried whether or not the backend says
+                # it changed anything.
+                if response.status_code == 403:
+                    headers, changed = await self.auth.authenticate_request_async(
+                        response, headers, refresh=True
+                    )
+                    await stream.__aexit__(None, None, None)
+                    stream, response = await open_stream(headers)
+
+            yield response
+        finally:
+            await stream.__aexit__(None, None, None)
+
     async def _do_paginated_request(
         self, url: str, callable: Callable[["httpx.Response"], bool]
     ):
@@ -295,32 +365,42 @@ class AsyncRegistry(RegistryBase):
         :type outfile: str
         """
         httpx_module = get_httpx()
-        try:
-            outdir = os.path.dirname(outfile)
-            if outdir and not os.path.exists(outdir):
-                oras.utils.mkdir_p(outdir)
+        blob_url = self._url(container.get_blob_url(digest))  # type: ignore
 
-            blob_url = self._url(container.get_blob_url(digest))  # type: ignore
-            headers = dict(self.headers)
-            if (
-                isinstance(self.auth, oras.auth.TokenAuth)
-                and self.auth.token is not None
-            ):
-                headers.update(self.auth.get_auth_header())
+        attempt = 0
+        while True:
+            try:
+                outdir = os.path.dirname(outfile)
+                if outdir and not os.path.exists(outdir):
+                    oras.utils.mkdir_p(outdir)
 
-            async with self.transport.stream(blob_url, "GET", headers=headers) as r:
-                r.raise_for_status()
-                with open(outfile, "wb") as f:
-                    async for chunk in r.aiter_bytes(chunk_size=8192):
-                        if chunk:
-                            f.write(chunk)
+                async with self.stream_request(
+                    blob_url, "GET", headers=self.headers
+                ) as r:
+                    r.raise_for_status()
 
-        # Allow an empty layer to fail and return /dev/null
-        except (httpx_module.HTTPError, OSError) as e:
-            if digest == oras.defaults.blank_hash:
-                return os.devnull
-            raise e
-        return outfile
+                    # opened inside the attempt so a retry starts a fresh file
+                    with open(outfile, "wb") as f:
+                        async for chunk in r.aiter_bytes(chunk_size=8192):
+                            if chunk:
+                                f.write(chunk)
+                return outfile
+
+            # Allow an empty layer to fail and return /dev/null
+            except (httpx_module.HTTPError, OSError) as e:
+                if digest == oras.defaults.blank_hash:
+                    return os.devnull
+
+                # Only a failed connection is worth another go. A status the
+                # registry meant, a 404 say, will say the same thing again.
+                if not isinstance(e, httpx_module.TransportError):
+                    raise
+                attempt += 1
+                if attempt >= DOWNLOAD_ATTEMPTS:
+                    raise
+                sleep = decorator.backoff_seconds(attempt - 1, DOWNLOAD_TIMEOUT)
+                logger.info(f"Retrying in {sleep} seconds - error: {e}")
+                await asyncio.sleep(sleep)
 
     async def _start_upload_session(self, container, headers: dict) -> str:
         """

--- a/oras/provider_async.py
+++ b/oras/provider_async.py
@@ -128,7 +128,7 @@ class AsyncRegistry(RegistryBase):
         response = await self.transport.request(
             url,
             method,
-            data=self._request_body(data),
+            data=data,
             headers=headers,
             json=json,
             params=params,
@@ -144,7 +144,7 @@ class AsyncRegistry(RegistryBase):
         response = await self.transport.request(
             url,
             method,
-            data=self._request_body(data),
+            data=data,
             headers=headers,
             json=json,
             params=params,
@@ -158,7 +158,7 @@ class AsyncRegistry(RegistryBase):
             response = await self.transport.request(
                 url,
                 method,
-                data=self._request_body(data),
+                data=data,
                 headers=headers,
                 json=json,
                 params=params,

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -1,0 +1,486 @@
+"""
+Tests for the asynchronous client.
+
+The unit tests swap in a fake transport, so registry logic can be checked
+without a registry and without httpx doing any real work. The integration
+tests exercise the httpx transport against a running registry, and skip when
+there is not one, in the same way as the synchronous integration tests.
+"""
+
+import asyncio
+import hashlib
+import os
+import pathlib
+
+import pytest
+
+import oras.auth.utils
+import oras.client
+import oras.defaults
+import oras.layout
+import oras.provider
+import oras.utils
+from oras.provider_async import AsyncRegistry
+from oras.transport_async import AsyncTransport
+
+# The async client is an extra, so skip rather than fail when it is absent
+httpx = pytest.importorskip("httpx")
+
+here = pathlib.Path(__file__).resolve().parent
+
+
+def digest_of(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+class FakeAsyncTransport:
+    """Records requests and returns canned responses, in order."""
+
+    def __init__(self, responses=None):
+        self.tls_verify = True
+        self.calls = []
+        self.responses = list(responses or [])
+        self.closed = False
+
+    async def request(
+        self, url, method="GET", data=None, headers=None, json=None, params=None
+    ):
+        self.calls.append(
+            {
+                "url": url,
+                "method": method,
+                "data": data,
+                "headers": dict(headers or {}),
+                "json": json,
+                "params": params,
+            }
+        )
+        if self.responses:
+            return self.responses.pop(0)
+        return httpx.Response(200)
+
+    async def aclose(self):
+        self.closed = True
+
+
+def get_registry(transport=None) -> AsyncRegistry:
+    return AsyncRegistry(
+        hostname="registry.example",
+        insecure=True,
+        transport=transport or FakeAsyncTransport(),  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------- construction
+
+
+def test_async_client_is_exposed_from_client_module():
+    assert oras.client.AsyncOrasClient is AsyncRegistry
+
+
+def test_async_registry_shares_its_transport_with_auth():
+    transport = FakeAsyncTransport()
+    registry = get_registry(transport)
+
+    assert registry.transport is transport
+    assert registry.auth.transport is transport
+
+
+def test_async_registry_builds_a_transport_by_default():
+    registry = AsyncRegistry(hostname="registry.example", tls_verify=False)
+
+    assert isinstance(registry.transport, AsyncTransport)
+    assert registry.transport.tls_verify is False
+
+
+def test_async_registry_shares_registry_logic_with_the_sync_provider():
+    """
+    The decisions live in one place, so both providers get them from there.
+    """
+    for shared in (
+        "_iter_push_layers",
+        "_iter_pull_targets",
+        "_prepare_manifest_config",
+        "_apply_manifest_annotations",
+        "_check_200_response",
+        "_get_location",
+        "_url",
+        "get_container",
+    ):
+        assert getattr(AsyncRegistry, shared) is getattr(oras.provider.Registry, shared)
+
+
+# ---------------------------------------------------------------- transport
+
+
+@pytest.mark.asyncio
+async def test_do_request_goes_through_the_transport():
+    transport = FakeAsyncTransport([httpx.Response(201)])
+    registry = get_registry(transport)
+
+    response = await registry.do_request(
+        "http://registry.example/v2/repo/manifests/v1", "PUT", json={"a": 1}
+    )
+
+    assert response.status_code == 201
+    (call,) = transport.calls
+    assert call["method"] == "PUT"
+    assert call["json"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_the_transport():
+    transport = FakeAsyncTransport()
+    registry = get_registry(transport)
+
+    await registry.aclose()
+
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_the_transport():
+    transport = FakeAsyncTransport()
+
+    async with get_registry(transport) as registry:
+        assert registry.transport is transport
+    assert transport.closed is True
+
+
+def test_transport_maps_bodies_onto_httpx_arguments():
+    """
+    requests takes bytes and forms through `data`, httpx separates them.
+    """
+    transport = AsyncTransport(client=object())
+
+    assert transport._content_arguments(None) == {}
+    assert transport._content_arguments(b"raw") == {"content": b"raw"}
+    assert transport._content_arguments({"a": "b"}) == {"data": {"a": "b"}}
+
+
+# ---------------------------------------------------------------- manifests
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_content_returns_bytes_and_digest():
+    body = b'{"schemaVersion":2}'
+    transport = FakeAsyncTransport(
+        [
+            httpx.Response(
+                200, content=body, headers={"Docker-Content-Digest": "sha256:a"}
+            )
+        ]
+    )
+    registry = get_registry(transport)
+
+    content, digest = await registry.get_manifest_content(
+        "registry.example/demo/artifact:v1"
+    )
+
+    assert content == body
+    assert digest == "sha256:a"
+    (call,) = transport.calls
+    assert call["url"] == "http://registry.example/v2/demo/artifact/manifests/v1"
+
+
+@pytest.mark.asyncio
+async def test_upload_manifest_content_sends_raw_bytes_by_reference():
+    transport = FakeAsyncTransport([httpx.Response(201)])
+    registry = get_registry(transport)
+    container = registry.get_container("registry.example/demo/artifact:v1")
+
+    await registry.upload_manifest_content(
+        b"{}", container, oras.defaults.default_index_media_type, reference="sha256:b"
+    )
+
+    (call,) = transport.calls
+    assert call["method"] == "PUT"
+    assert call["data"] == b"{}"
+    assert call["headers"]["Content-Type"] == oras.defaults.default_index_media_type
+    assert call["url"] == "http://registry.example/v2/demo/artifact/manifests/sha256:b"
+
+
+# ---------------------------------------------------------------- auth
+
+
+@pytest.mark.asyncio
+async def test_authentication_challenge_is_answered_and_retried_asynchronously():
+    """
+    401 -> token request -> retry, all awaited on the async transport.
+    """
+    challenge = httpx.Response(
+        401,
+        headers={
+            "Www-Authenticate": 'Bearer realm="https://auth.example/token",service="registry.example"'
+        },
+    )
+    token = httpx.Response(200, json={"token": "a-token"})
+    transport = FakeAsyncTransport([challenge, token, httpx.Response(200)])
+    registry = get_registry(transport)
+
+    response = await registry.do_request("http://registry.example/v2/demo/tags/list")
+
+    assert response.status_code == 200
+    assert len(transport.calls) == 3
+
+    # the token came from the realm, over the same async transport
+    assert transport.calls[1]["url"] == "https://auth.example/token"
+    assert transport.calls[1]["params"] == {"service": "registry.example"}
+
+    # and the retry carried it
+    assert transport.calls[2]["headers"]["Authorization"] == "Bearer a-token"
+    assert registry.auth.token == "a-token"
+
+
+@pytest.mark.asyncio
+async def test_basic_auth_answers_a_challenge_without_a_token_request():
+    challenge = httpx.Response(401, headers={"Www-Authenticate": 'Basic realm="r"'})
+    transport = FakeAsyncTransport([challenge, httpx.Response(200)])
+    registry = AsyncRegistry(
+        hostname="registry.example",
+        insecure=True,
+        auth_backend="basic",
+        transport=transport,
+    )
+    registry.auth.set_basic_auth("myuser", "mypass")
+
+    response = await registry.do_request("http://registry.example/v2/")
+
+    assert response.status_code == 200
+    assert len(transport.calls) == 2
+    assert transport.calls[1]["headers"]["Authorization"].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_challenge_without_a_www_authenticate_header_is_not_answered():
+    """
+    Nothing to answer means no retry, matching the synchronous backend.
+    """
+    registry = get_registry()
+
+    headers, changed = await registry.auth.authenticate_request_async(
+        httpx.Response(401), {}
+    )
+
+    assert changed is False
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_a_refused_token_request_yields_no_token():
+    transport = FakeAsyncTransport([httpx.Response(403, content=b"{}")])
+    registry = get_registry(transport)
+    header = oras.auth.utils.parse_auth_header(
+        'Bearer realm="https://auth.example/token"'
+    )
+
+    assert await registry.auth.request_token_async(header) is None
+
+
+# ---------------------------------------------------------------- integration
+
+
+@pytest.fixture
+def async_target(registry):
+    return f"{registry}/dinosaur/async-artifact:v1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_push_pull_file(tmp_path, registry, credentials, async_target):
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            oras.utils.write_file("artifact.txt", "async round trip\n")
+            response = await client.push(
+                files=["artifact.txt"],
+                target=async_target,
+                manifest_annotations={"mode": "async"},
+            )
+            assert response.status_code in (200, 201)
+
+        outdir = str(tmp_path / "out")
+        files = await client.pull(async_target, outdir=outdir)
+        assert len(files) == 1
+        assert oras.utils.read_file(files[0]) == "async round trip\n"
+
+        manifest = await client.get_manifest(async_target)
+        assert manifest["annotations"]["mode"] == "async"
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_push_pull_directory(tmp_path, registry, credentials):
+    target = f"{registry}/dinosaur/async-directory:v1"
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            os.makedirs("bundle", exist_ok=True)
+            oras.utils.write_file(os.path.join("bundle", "inner.txt"), "nested\n")
+            response = await client.push(files=["bundle"], target=target)
+            assert response.status_code in (200, 201)
+
+        files = await client.pull(target, outdir=str(tmp_path / "dirout"))
+        assert len(files) == 1
+        assert os.path.isdir(files[0])
+        assert "inner.txt" in os.listdir(files[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_chunked_upload(tmp_path, registry, credentials):
+    target = f"{registry}/dinosaur/async-chunked:v1"
+    payload = ("chunk" * 20000).encode()
+
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            pathlib.Path("chunked.bin").write_bytes(payload)
+            response = await client.push(
+                files=["chunked.bin"],
+                target=target,
+                do_chunked=True,
+                chunk_size=4096,
+            )
+            assert response.status_code in (200, 201, 202)
+
+        files = await client.pull(target, outdir=str(tmp_path / "chunkout"))
+        assert pathlib.Path(files[0]).read_bytes() == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_large_blob_round_trips(tmp_path, registry, credentials):
+    """
+    A blob larger than the read buffer, to exercise streaming both ways.
+    """
+    target = f"{registry}/dinosaur/async-large:v1"
+    payload = os.urandom(5 * 1024 * 1024)
+
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            pathlib.Path("large.bin").write_bytes(payload)
+            response = await client.push(files=["large.bin"], target=target)
+            assert response.status_code in (200, 201)
+
+        files = await client.pull(target, outdir=str(tmp_path / "largeout"))
+        assert digest_of(pathlib.Path(files[0]).read_bytes()) == digest_of(payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_digest_reference_and_tags(tmp_path, registry, credentials):
+    repository = f"{registry}/dinosaur/async-refs"
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            oras.utils.write_file("ref.txt", "by digest\n")
+            await client.push(files=["ref.txt"], target=f"{repository}:v1")
+
+        content, digest = await client.get_manifest_content(f"{repository}:v1")
+        assert digest == digest_of(content)
+
+        by_digest = await client.get_manifest(f"{repository}@{digest}")
+        assert by_digest["schemaVersion"] == 2
+
+        tags = await client.get_tags(repository)
+        assert "v1" in tags
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_index_is_pushed_and_read_back(tmp_path, registry, credentials):
+    """
+    An image index pushed as exact bytes, then read back unchanged.
+    """
+    layout = oras.layout.Layout(str(here / "ocilayout_data" / "ocilayout2"))
+    index_digest = oras.utils.read_json(
+        str(here / "ocilayout_data" / "ocilayout2" / "index.json")
+    )["manifests"][0]["digest"]
+    index_bytes = layout.digest_to_blob_path(index_digest).read_bytes()
+
+    target = f"{registry}/dinosaur/async-index:v1"
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        container = client.get_container(target)
+
+        # the blobs the index refers to have to exist before it does
+        for digest in layout.get_ordered_blobs("latest"):
+            blob_path = layout.digest_to_blob_path(digest)
+            blob = blob_path.read_bytes()
+            try:
+                media_type = oras.utils.read_json(str(blob_path)).get("mediaType", "")
+            except Exception:
+                media_type = ""
+            if media_type in (
+                oras.defaults.default_manifest_media_type,
+                oras.defaults.default_index_media_type,
+            ):
+                if digest == index_digest:
+                    continue
+                response = await client.upload_manifest_content(
+                    blob, container, media_type, reference=digest
+                )
+            else:
+                layer = {
+                    "digest": digest,
+                    "size": blob_path.stat().st_size,
+                    "mediaType": media_type or oras.defaults.unknown_config_media_type,
+                }
+                response = await client.upload_blob(str(blob_path), container, layer)
+            client._check_200_response(response)
+
+        response = await client.upload_manifest_content(
+            index_bytes, container, oras.defaults.default_index_media_type
+        )
+        client._check_200_response(response)
+
+        content, digest = await client.get_manifest_content(
+            target, allowed_media_type=[oras.defaults.default_index_media_type]
+        )
+        assert content == index_bytes
+        assert digest == index_digest
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_operations_run_concurrently(tmp_path, registry, credentials):
+    target = f"{registry}/dinosaur/async-concurrent:v1"
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            oras.utils.write_file("shared.txt", "concurrent\n")
+            await client.push(files=["shared.txt"], target=target)
+
+        results = await asyncio.gather(
+            client.pull(target, outdir=str(tmp_path / "a")),
+            client.pull(target, outdir=str(tmp_path / "b")),
+            client.get_manifest(target),
+            client.get_tags(f"{registry}/dinosaur/async-concurrent"),
+        )
+
+    assert len(results[0]) == 1 and len(results[1]) == 1
+    assert results[2]["schemaVersion"] == 2
+    assert "v1" in results[3]
+
+    # one shared token cache, one agreed answer
+    assert client.auth.token is None or isinstance(client.auth.token, str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_pull_can_be_cancelled(tmp_path, registry, credentials):
+    target = f"{registry}/dinosaur/async-cancel:v1"
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with oras.utils.workdir(str(tmp_path)):
+            pathlib.Path("cancel.bin").write_bytes(os.urandom(2 * 1024 * 1024))
+            await client.push(files=["cancel.bin"], target=target)
+
+        task = asyncio.create_task(client.pull(target, outdir=str(tmp_path / "c")))
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_auth(False)
+async def test_async_missing_manifest_raises_value_error(registry, credentials):
+    async with AsyncRegistry(hostname=registry, insecure=True) as client:
+        with pytest.raises(ValueError):
+            await client.get_manifest(f"{registry}/dinosaur/does-not-exist:v1")

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import os
 import pathlib
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -676,3 +677,151 @@ async def test_streamed_body_survives_a_redirect():
 
 async def iter_bytes(payload: bytes):
     yield payload
+
+
+# ---------------------------------------------------------------- streamed auth
+
+
+class StreamingTransport(FakeAsyncTransport):
+    """
+    A transport whose stream() can be told what to answer with.
+
+    Records the headers of every stream that is opened, which is how the
+    authentication of a download is checked.
+    """
+
+    def __init__(self, statuses=None, transport_errors=0):
+        super().__init__()
+        self.statuses = list(statuses or [200])
+        self.opened = []
+        self.transport_errors = transport_errors
+
+    @asynccontextmanager
+    async def stream(self, url, method="GET", headers=None, params=None):
+        self.opened.append(dict(headers or {}))
+        if self.transport_errors:
+            self.transport_errors -= 1
+            raise httpx.ConnectError("connection lost")
+        status = self.statuses.pop(0) if self.statuses else 200
+        challenge = (
+            {
+                "Www-Authenticate": 'Bearer realm="https://auth.example/token",service="reg"'
+            }
+            if status == 401
+            else {}
+        )
+        yield httpx.Response(
+            status,
+            headers=challenge,
+            content=b"blob-bytes",
+            request=httpx.Request(method, url),
+        )
+
+    async def request(
+        self, url, method="GET", data=None, headers=None, json=None, params=None
+    ):
+        if "auth.example" in url:
+            return httpx.Response(200, json={"token": "a-token"})
+        return await super().request(
+            url, method, data=data, headers=headers, json=json, params=params
+        )
+
+
+async def download(transport, tmp_path, backend="token", setup=None):
+    registry = AsyncRegistry(
+        hostname="registry.example",
+        insecure=True,
+        auth_backend=backend,
+        transport=transport,  # type: ignore[arg-type]
+    )
+    if setup:
+        setup(registry)
+    container = registry.get_container("registry.example/demo/artifact:v1")
+    outfile = str(tmp_path / "blob.bin")
+    await registry.download_blob(container, "sha256:" + "a" * 64, outfile)
+    return outfile
+
+
+def authorizations(transport):
+    return [opened.get("Authorization", None) for opened in transport.opened]
+
+
+@pytest.mark.asyncio
+async def test_download_answers_a_token_challenge(tmp_path):
+    """
+    A download is authenticated like any other request, not left to fail.
+    """
+    transport = StreamingTransport([401, 200])
+
+    outfile = await download(transport, tmp_path)
+
+    assert authorizations(transport) == [None, "Bearer a-token"]
+    assert pathlib.Path(outfile).read_bytes() == b"blob-bytes"
+
+
+@pytest.mark.asyncio
+async def test_download_answers_a_basic_challenge(tmp_path):
+    transport = StreamingTransport([401, 200])
+
+    await download(
+        transport,
+        tmp_path,
+        backend="basic",
+        setup=lambda r: r.auth.set_basic_auth("myuser", "mypass"),
+    )
+
+    assert authorizations(transport)[1].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_download_refreshes_after_a_403(tmp_path):
+    """
+    A token scoped too narrowly for the blob endpoint gets another chance.
+    """
+    transport = StreamingTransport([401, 403, 200])
+
+    await download(transport, tmp_path)
+
+    assert len(transport.opened) == 3
+
+
+@pytest.mark.asyncio
+async def test_download_reuses_a_token_it_already_holds(tmp_path):
+    transport = StreamingTransport([200])
+    registry = AsyncRegistry(
+        hostname="registry.example",
+        insecure=True,
+        transport=transport,  # type: ignore[arg-type]
+    )
+    registry.auth.token = "held-token"
+    container = registry.get_container("registry.example/demo/artifact:v1")
+
+    await registry.download_blob(
+        container, "sha256:" + "a" * 64, str(tmp_path / "blob.bin")
+    )
+
+    assert authorizations(transport) == ["Bearer held-token"]
+
+
+@pytest.mark.asyncio
+async def test_download_retries_a_failed_connection(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras.decorator, "backoff_seconds", lambda attempt, timeout: 0)
+    transport = StreamingTransport([200], transport_errors=2)
+
+    outfile = await download(transport, tmp_path)
+
+    assert len(transport.opened) == 3, "two failures, then a success"
+    assert pathlib.Path(outfile).read_bytes() == b"blob-bytes"
+
+
+@pytest.mark.asyncio
+async def test_download_does_not_retry_a_status_the_registry_meant(tmp_path):
+    """
+    A 404 says the same thing however many times it is asked.
+    """
+    transport = StreamingTransport([404])
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await download(transport, tmp_path)
+
+    assert len(transport.opened) == 1

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -16,6 +16,7 @@ import pytest
 
 import oras.auth.utils
 import oras.client
+import oras.decorator
 import oras.defaults
 import oras.layout
 import oras.provider
@@ -484,3 +485,135 @@ async def test_async_missing_manifest_raises_value_error(registry, credentials):
     async with AsyncRegistry(hostname=registry, insecure=True) as client:
         with pytest.raises(ValueError):
             await client.get_manifest(f"{registry}/dinosaur/does-not-exist:v1")
+
+
+# ---------------------------------------------------------------- resent bodies
+
+
+async def drain(body):
+    """Read a body the way a real transport would."""
+    if body is None:
+        return b""
+    if isinstance(body, (bytes, bytearray)):
+        return bytes(body)
+    chunks = []
+    async for chunk in body:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+class BodyRecordingTransport(FakeAsyncTransport):
+    """
+    Reads each body, as a real transport does, and records what arrived.
+
+    Reading matters: a body that can only be read once looks fine until
+    something reads it twice.
+    """
+
+    def __init__(self, responses=None, fail_first=False):
+        super().__init__(responses)
+        self.bodies = []
+        self.fail_first = fail_first
+        self.sent = 0
+
+    async def request(
+        self, url, method="GET", data=None, headers=None, json=None, params=None
+    ):
+        body = await drain(data)
+        if method == "PUT":
+            self.bodies.append(body)
+            self.sent += 1
+            if self.fail_first and self.sent == 1:
+                raise httpx.ConnectError("boom")
+        return await super().request(
+            url, method, data=data, headers=headers, json=json, params=params
+        )
+
+
+def upload_layer(payload: bytes) -> dict:
+    return {
+        "digest": digest_of(payload),
+        "size": len(payload),
+        "mediaType": "application/octet-stream",
+    }
+
+
+def blob_file(tmp_path, payload: bytes) -> str:
+    path = tmp_path / "blob.bin"
+    path.write_bytes(payload)
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_upload_body_survives_an_authentication_challenge(tmp_path):
+    """
+    The blob PUT is re-sent to answer a 401, and must carry the same bytes.
+
+    A body read straight from disk is spent after the first send, which would
+    leave the retry declaring a Content-Length and digest for content it did
+    not actually send.
+    """
+    payload = b"hello world"
+    session = httpx.Response(
+        202, headers={"location": "http://registry.example/v2/demo/blobs/uploads/1"}
+    )
+    challenge = httpx.Response(
+        401,
+        headers={
+            "Www-Authenticate": 'Bearer realm="https://auth.example/token",service="registry.example"'
+        },
+    )
+    token = httpx.Response(200, json={"token": "a-token"})
+    transport = BodyRecordingTransport([session, challenge, token, httpx.Response(201)])
+    registry = get_registry(transport)
+    container = registry.get_container("registry.example/demo/artifact:v1")
+
+    await registry.put_upload(
+        blob_file(tmp_path, payload), container, upload_layer(payload)
+    )
+
+    assert len(transport.bodies) == 2, "expected the PUT to be sent twice"
+    assert transport.bodies == [payload, payload]
+
+
+@pytest.mark.asyncio
+async def test_upload_body_survives_a_retry(tmp_path, monkeypatch):
+    """
+    The same holds when the retry decorator re-sends after a failure.
+    """
+    monkeypatch.setattr(oras.decorator, "backoff_seconds", lambda attempt, timeout: 0)
+
+    payload = b"retried payload"
+    session = httpx.Response(
+        202, headers={"location": "http://registry.example/v2/demo/blobs/uploads/1"}
+    )
+    transport = BodyRecordingTransport(
+        [session, session, httpx.Response(201)], fail_first=True
+    )
+    registry = get_registry(transport)
+    container = registry.get_container("registry.example/demo/artifact:v1")
+
+    await registry.put_upload(
+        blob_file(tmp_path, payload), container, upload_layer(payload)
+    )
+
+    assert len(transport.bodies) == 2, "expected the PUT to be sent twice"
+    assert transport.bodies == [payload, payload]
+
+
+def test_request_body_resolves_callables_and_passes_the_rest_through():
+    registry = get_registry()
+
+    assert registry._request_body(b"raw") == b"raw"
+    assert registry._request_body({"a": "b"}) == {"a": "b"}
+    assert registry._request_body(None) is None
+
+    produced = []
+
+    def factory():
+        produced.append(len(produced))
+        return b"fresh"
+
+    assert registry._request_body(factory) == b"fresh"
+    assert registry._request_body(factory) == b"fresh"
+    assert produced == [0, 1], "a callable body is produced again for each attempt"

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -491,7 +491,9 @@ async def test_async_missing_manifest_raises_value_error(registry, credentials):
 
 
 async def drain(body):
-    """Read a body the way a real transport would."""
+    """Resolve and read a body the way a real transport would."""
+    if callable(body):
+        body = body()
     if body is None:
         return b""
     if isinstance(body, (bytes, bytearray)):
@@ -601,19 +603,76 @@ async def test_upload_body_survives_a_retry(tmp_path, monkeypatch):
     assert transport.bodies == [payload, payload]
 
 
-def test_request_body_resolves_callables_and_passes_the_rest_through():
-    registry = get_registry()
+# ---------------------------------------------------------------- redirects
 
-    assert registry._request_body(b"raw") == b"raw"
-    assert registry._request_body({"a": "b"}) == {"a": "b"}
-    assert registry._request_body(None) is None
 
-    produced = []
+class RedirectingServer:
+    """
+    A real HTTP server that redirects the first PUT, and records each body.
 
-    def factory():
-        produced.append(len(produced))
-        return b"fresh"
+    This is deliberately not a fake transport: the bug it guards against lives
+    inside httpx's own redirect handling, below where a fake would sit.
+    """
 
-    assert registry._request_body(factory) == b"fresh"
-    assert registry._request_body(factory) == b"fresh"
-    assert produced == [0, 1], "a callable body is produced again for each attempt"
+    def __init__(self, redirect_status=307):
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        self.received = []
+        received = self.received
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_PUT(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                received.append((self.path, body))
+                if self.path.endswith("/first"):
+                    self.send_response(redirect_status)
+                    self.send_header("Location", "/second")
+                else:
+                    self.send_response(201)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+
+    def __enter__(self):
+        import threading
+
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_streamed_body_survives_a_redirect():
+    """
+    Registries backed by object storage redirect blob uploads, and httpx
+    cannot replay a body it has already streamed. Each hop must get a fresh one.
+    """
+    payload = b"hello world"
+
+    with RedirectingServer() as server:
+        transport = AsyncTransport()
+        try:
+            response = await transport.request(
+                f"http://127.0.0.1:{server.port}/first",
+                "PUT",
+                data=lambda: iter_bytes(payload),
+                headers={"Content-Length": str(len(payload))},
+            )
+        finally:
+            await transport.aclose()
+
+    assert response.status_code == 201
+    assert [path for path, _ in server.received] == ["/first", "/second"]
+    assert [body for _, body in server.received] == [payload, payload]
+
+
+async def iter_bytes(payload: bytes):
+    yield payload

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import os
 import pathlib
+import ssl
 from contextlib import asynccontextmanager
 
 import pytest
@@ -825,3 +826,75 @@ async def test_download_does_not_retry_a_status_the_registry_meant(tmp_path):
         await download(transport, tmp_path)
 
     assert len(transport.opened) == 1
+
+
+# ---------------------------------------------------------------- retry policy
+
+
+def ssl_backed_connect_error():
+    """
+    A ConnectError shaped the way httpx reports a bad certificate.
+    """
+    error = httpx.ConnectError("connection failed")
+    error.__cause__ = ssl.SSLCertVerificationError("certificate verify failed")
+    return error
+
+
+def test_a_certificate_failure_is_recognised_through_the_cause_chain():
+    """
+    httpx reports a bad certificate and a refused connection the same way, so
+    only the cause tells them apart.
+    """
+    assert oras.decorator.is_certificate_error(ssl_backed_connect_error()) is True
+
+    refused = httpx.ConnectError("connection failed")
+    refused.__cause__ = ConnectionRefusedError("refused")
+    assert oras.decorator.is_certificate_error(refused) is False
+
+    assert (
+        oras.decorator.is_certificate_error(ValueError("nothing to do with tls"))
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_async_does_not_retry_a_certificate_failure(monkeypatch):
+    """
+    A wrong certificate will not fix itself, so it is reported at once rather
+    than after every attempt has slept.
+    """
+    slept = []
+    monkeypatch.setattr(asyncio, "sleep", lambda n: slept.append(n))
+    attempts = []
+
+    @oras.decorator.retry_async(attempts=5, timeout=2)
+    async def failing():
+        attempts.append(1)
+        raise ssl_backed_connect_error()
+
+    with pytest.raises(httpx.ConnectError):
+        await failing()
+
+    assert len(attempts) == 1, "the request should be made once"
+    assert slept == [], "and nothing should be slept through"
+
+
+@pytest.mark.asyncio
+async def test_retry_async_still_retries_a_refused_connection(monkeypatch):
+    """
+    A refused connection may well succeed later, and is retried as before.
+    """
+    monkeypatch.setattr(oras.decorator, "backoff_seconds", lambda attempt, timeout: 0)
+    attempts = []
+
+    @oras.decorator.retry_async(attempts=3, timeout=2)
+    async def failing():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise httpx.ConnectError("connection refused")
+        return httpx.Response(200)
+
+    response = await failing()
+
+    assert response.status_code == 200
+    assert len(attempts) == 3, "it should keep trying"

--- a/oras/tests/test_async.py
+++ b/oras/tests/test_async.py
@@ -154,7 +154,7 @@ def test_transport_maps_bodies_onto_httpx_arguments():
     """
     requests takes bytes and forms through `data`, httpx separates them.
     """
-    transport = AsyncTransport(client=object())
+    transport = AsyncTransport(client=httpx.AsyncClient())
 
     assert transport._content_arguments(None) == {}
     assert transport._content_arguments(b"raw") == {"content": b"raw"}
@@ -898,3 +898,96 @@ async def test_retry_async_still_retries_a_refused_connection(monkeypatch):
 
     assert response.status_code == 200
     assert len(attempts) == 3, "it should keep trying"
+
+
+# ---------------------------------------------------------------- cookies
+
+
+class CookieServer:
+    """
+    A real server that sets a cookie on every response, and records what it
+    was sent. Registries that do this treat an accepted cookie as a sign they
+    are talking to a browser, and start asking for CSRF tokens.
+    """
+
+    def __init__(self):
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        self.received = []
+        received = self.received
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                received.append((self.path, self.headers.get("Cookie")))
+                if self.path == "/redirect":
+                    self.send_response(307)
+                    self.send_header("Set-Cookie", "sid=from-redirect; Path=/")
+                    self.send_header("Location", "/after")
+                elif self.path == "/blob":
+                    self.send_response(200)
+                    self.send_header("Set-Cookie", "sid=from-blob; Path=/")
+                    self.send_header("Content-Length", "9")
+                    self.end_headers()
+                    self.wfile.write(b"blob-body")
+                    return
+                else:
+                    self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def __enter__(self):
+        import threading
+
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+
+    def cookies_sent(self):
+        return [cookie for _, cookie in self.received]
+
+
+@pytest.mark.asyncio
+async def test_a_cookie_from_a_streamed_response_is_refused():
+    """
+    Downloads are most of the traffic, and they stream, so a cookie set on one
+    must not be kept for later requests.
+    """
+    with CookieServer() as server:
+        transport = AsyncTransport()
+        try:
+            async with transport.stream(f"{server.url}/blob") as response:
+                async for _ in response.aiter_bytes():
+                    pass
+
+            assert list(transport.client.cookies.jar) == []
+
+            await transport.request(f"{server.url}/next")
+        finally:
+            await transport.aclose()
+
+    assert server.cookies_sent() == [None, None], "no cookie should be sent back"
+
+
+@pytest.mark.asyncio
+async def test_a_cookie_is_not_carried_across_a_redirect():
+    """
+    Refusing a cookie has to happen as the response is read, not afterwards,
+    or it is still sent on the next leg of the same request.
+    """
+    with CookieServer() as server:
+        transport = AsyncTransport()
+        try:
+            await transport.request(f"{server.url}/redirect")
+        finally:
+            await transport.aclose()
+
+    assert [path for path, _ in server.received] == ["/redirect", "/after"]
+    assert server.cookies_sent() == [None, None]

--- a/oras/tests/test_transport.py
+++ b/oras/tests/test_transport.py
@@ -1,0 +1,258 @@
+"""
+Tests for the transport boundary, and the registry operations built on it.
+
+These do not need a running registry: the transport can be swapped for a fake
+one, which is the point of keeping request execution behind a small interface.
+"""
+
+import requests
+
+import oras.defaults
+import oras.provider
+from oras.transport import Transport, successful_response
+
+
+def make_response(status_code: int = 200, content: bytes = b"", headers=None):
+    """
+    Build a requests response to hand back from a fake transport.
+    """
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = content
+    response.headers.update(headers or {})
+    return response
+
+
+class FakeSession:
+    """Records requests instead of sending them."""
+
+    def __init__(self, response=None):
+        self.calls = []
+        self.cookies = requests.cookies.RequestsCookieJar()
+        self.response = response or make_response()
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return self.response
+
+
+class FakeTransport:
+    """Stands in for a Transport, returning canned responses in order."""
+
+    def __init__(self, responses=None):
+        self.session = None
+        self.tls_verify = True
+        self.calls = []
+        self.responses = list(responses or [])
+
+    def request(
+        self, url, method="GET", data=None, headers=None, json=None, stream=False
+    ):
+        self.calls.append(
+            {
+                "url": url,
+                "method": method,
+                "data": data,
+                "headers": headers,
+                "json": json,
+                "stream": stream,
+            }
+        )
+        if self.responses:
+            return self.responses.pop(0)
+        return make_response()
+
+
+def get_registry(transport=None):
+    """
+    An insecure registry, with an optional transport swapped in.
+    """
+    registry = oras.provider.Registry(hostname="registry.example", insecure=True)
+    if transport is not None:
+        registry.transport = transport
+    return registry
+
+
+def test_transport_request_forwards_arguments():
+    session = FakeSession()
+    transport = Transport(session=session, tls_verify=False)
+
+    transport.request(
+        "http://registry.example/v2/",
+        "PUT",
+        data=b"content",
+        headers={"Content-Type": "application/octet-stream"},
+        stream=True,
+    )
+
+    (call,) = session.calls
+    assert call["method"] == "PUT"
+    assert call["url"] == "http://registry.example/v2/"
+    assert call["data"] == b"content"
+    assert call["headers"] == {"Content-Type": "application/octet-stream"}
+    assert call["stream"] is True
+
+    # tls_verify is applied by the transport, not by callers
+    assert call["verify"] is False
+
+
+def test_transport_applies_custom_ca_bundle():
+    session = FakeSession()
+    transport = Transport(session=session, tls_verify="/path/to/ca-bundle.crt")
+
+    transport.request("https://registry.example/v2/")
+
+    assert session.calls[0]["verify"] == "/path/to/ca-bundle.crt"
+
+
+def test_transport_rejects_cookies():
+    """
+    Registries that see cookies accepted may treat the client as a browser.
+    """
+    transport = Transport()
+    assert transport.session.cookies.get_policy().allowed_domains() == ()
+
+
+def test_successful_response():
+    assert successful_response().status_code == 200
+    assert successful_response(201).status_code == 201
+
+
+def test_registry_session_comes_from_transport():
+    registry = get_registry()
+
+    assert registry.session is registry.transport.session
+
+    # The auth backend shares the session with the provider
+    assert registry.auth.session is registry.session
+
+
+def test_registry_session_can_be_replaced():
+    registry = get_registry()
+    session = requests.Session()
+
+    registry.session = session
+
+    assert registry.session is session
+    assert registry.transport.session is session
+
+
+def test_registry_tls_verify_reads_and_writes_transport():
+    registry = oras.provider.Registry(hostname="registry.example", tls_verify=False)
+    assert registry._tls_verify is False
+
+    registry._tls_verify = True
+    assert registry.transport.tls_verify is True
+
+
+def test_do_request_goes_through_the_transport():
+    transport = FakeTransport([make_response(201)])
+    registry = get_registry(transport)
+
+    response = registry.do_request(
+        "http://registry.example/v2/repository/manifests/tag", "PUT", json={"a": 1}
+    )
+
+    assert response.status_code == 201
+    (call,) = transport.calls
+    assert call["method"] == "PUT"
+    assert call["url"] == "http://registry.example/v2/repository/manifests/tag"
+    assert call["json"] == {"a": 1}
+
+
+def test_get_manifest_content_returns_bytes_and_digest():
+    digest = "sha256:aaaa"
+    transport = FakeTransport(
+        [
+            make_response(
+                content=b'{"schemaVersion":2}',
+                headers={"Docker-Content-Digest": digest},
+            )
+        ]
+    )
+    registry = get_registry(transport)
+
+    content, reported_digest = registry.get_manifest_content(
+        "registry.example/dinosaur/artifact:v1"
+    )
+
+    # The bytes are handed back untouched, so the digest still matches
+    assert content == b'{"schemaVersion":2}'
+    assert reported_digest == digest
+
+    (call,) = transport.calls
+    assert call["method"] == "GET"
+    assert call["url"] == "http://registry.example/v2/dinosaur/artifact/manifests/v1"
+    assert call["headers"]["Accept"] == ", ".join(
+        oras.defaults.default_manifest_accepted_media_types
+    )
+
+
+def test_get_manifest_content_without_digest_header():
+    transport = FakeTransport([make_response(content=b"{}")])
+    registry = get_registry(transport)
+
+    _, reported_digest = registry.get_manifest_content(
+        "registry.example/dinosaur/artifact:v1"
+    )
+
+    assert reported_digest is None
+
+
+def test_get_manifest_content_by_reference():
+    digest = "sha256:bbbb"
+    transport = FakeTransport([make_response(content=b"{}")])
+    registry = get_registry(transport)
+
+    registry.get_manifest_content(
+        "registry.example/dinosaur/artifact:v1",
+        allowed_media_type=[oras.defaults.default_manifest_media_type],
+        reference=digest,
+    )
+
+    (call,) = transport.calls
+    assert (
+        call["url"]
+        == f"http://registry.example/v2/dinosaur/artifact/manifests/{digest}"
+    )
+    assert call["headers"]["Accept"] == oras.defaults.default_manifest_media_type
+
+
+def test_upload_manifest_content_sends_raw_bytes():
+    transport = FakeTransport([make_response(201)])
+    registry = get_registry(transport)
+    container = registry.get_container("registry.example/dinosaur/artifact:v1")
+
+    response = registry.upload_manifest_content(
+        b'{"schemaVersion":2}',
+        container,
+        oras.defaults.default_index_media_type,
+    )
+
+    assert response.status_code == 201
+    (call,) = transport.calls
+    assert call["method"] == "PUT"
+    assert call["data"] == b'{"schemaVersion":2}'
+    assert call["json"] is None
+    assert call["headers"] == {"Content-Type": oras.defaults.default_index_media_type}
+    assert call["url"] == "http://registry.example/v2/dinosaur/artifact/manifests/v1"
+
+
+def test_upload_manifest_content_by_reference():
+    digest = "sha256:cccc"
+    transport = FakeTransport([make_response(201)])
+    registry = get_registry(transport)
+    container = registry.get_container("registry.example/dinosaur/artifact:v1")
+
+    registry.upload_manifest_content(
+        b"{}",
+        container,
+        oras.defaults.default_manifest_media_type,
+        reference=digest,
+    )
+
+    (call,) = transport.calls
+    assert (
+        call["url"]
+        == f"http://registry.example/v2/dinosaur/artifact/manifests/{digest}"
+    )

--- a/oras/tests/test_transport.py
+++ b/oras/tests/test_transport.py
@@ -11,7 +11,7 @@ import oras.auth
 import oras.auth.utils as auth_utils
 import oras.defaults
 import oras.provider
-from oras.transport import Transport, successful_response
+from oras.transport import Transport, resolve_body, successful_response
 
 
 def make_response(status_code: int = 200, content: bytes = b"", headers=None):
@@ -432,29 +432,26 @@ def test_token_request_returns_nothing_when_refused():
     assert backend.request_token(header) is None
 
 
-def test_do_request_resolves_a_callable_body_for_each_attempt():
-    """
-    A body that can only be read once is produced again when the request is
-    re-sent to answer an authentication challenge.
-    """
-    challenge = make_response(401, headers={"Www-Authenticate": 'Basic realm="r"'})
-    transport = FakeTransport([challenge, make_response(200)])
-    registry = oras.provider.Registry(
-        hostname="registry.example",
-        insecure=True,
-        auth_backend="basic",
-        transport=transport,
-    )
-    registry.auth.set_basic_auth("myuser", "mypass")
-
+def test_resolve_body_produces_a_fresh_body_for_each_attempt():
     produced = []
 
-    def body():
-        produced.append(b"payload")
-        return b"payload"
+    def factory():
+        produced.append(len(produced))
+        return b"fresh"
 
-    registry.do_request("http://registry.example/v2/", "PUT", data=body)
+    assert resolve_body(b"raw") == b"raw"
+    assert resolve_body({"a": "b"}) == {"a": "b"}
+    assert resolve_body(None) is None
+    assert resolve_body(factory) == b"fresh"
+    assert resolve_body(factory) == b"fresh"
+    assert produced == [0, 1], "a callable body is produced again for each send"
 
-    assert len(transport.calls) == 2
-    assert [call["data"] for call in transport.calls] == [b"payload", b"payload"]
-    assert produced == [b"payload", b"payload"], "body produced once per attempt"
+
+def test_transport_resolves_a_callable_body_at_the_send():
+    session = FakeSession()
+    transport = Transport(session=session)
+
+    transport.request("https://registry.example/v2/", "PUT", data=lambda: b"payload")
+    transport.request("https://registry.example/v2/", "PUT", data=lambda: b"payload")
+
+    assert [call["data"] for call in session.calls] == [b"payload", b"payload"]

--- a/oras/tests/test_transport.py
+++ b/oras/tests/test_transport.py
@@ -7,6 +7,8 @@ one, which is the point of keeping request execution behind a small interface.
 
 import requests
 
+import oras.auth
+import oras.auth.utils as auth_utils
 import oras.defaults
 import oras.provider
 from oras.transport import Transport, successful_response
@@ -46,7 +48,14 @@ class FakeTransport:
         self.responses = list(responses or [])
 
     def request(
-        self, url, method="GET", data=None, headers=None, json=None, stream=False
+        self,
+        url,
+        method="GET",
+        data=None,
+        headers=None,
+        json=None,
+        stream=False,
+        params=None,
     ):
         self.calls.append(
             {
@@ -56,6 +65,7 @@ class FakeTransport:
                 "headers": headers,
                 "json": json,
                 "stream": stream,
+                "params": params,
             }
         )
         if self.responses:
@@ -256,3 +266,167 @@ def test_upload_manifest_content_by_reference():
         call["url"]
         == f"http://registry.example/v2/dinosaur/artifact/manifests/{digest}"
     )
+
+
+def test_transport_forwards_query_parameters():
+    """
+    Token requests need query parameters, so the transport has to carry them.
+    """
+    session = FakeSession()
+    transport = Transport(session=session)
+
+    transport.request(
+        "https://auth.example/token",
+        params={"service": "registry.example", "scope": "repository:demo:pull"},
+    )
+
+    assert session.calls[0]["params"] == {
+        "service": "registry.example",
+        "scope": "repository:demo:pull",
+    }
+
+
+def test_transport_streams_without_reading_the_body():
+    session = FakeSession()
+    transport = Transport(session=session)
+
+    transport.request("https://registry.example/v2/repo/blobs/sha256:abc", stream=True)
+
+    assert session.calls[0]["stream"] is True
+
+
+def test_transport_passes_file_objects_through_unread(tmp_path):
+    """
+    A file object must reach requests as-is, so uploads are not buffered here.
+    """
+    blob = tmp_path / "blob.bin"
+    blob.write_bytes(b"some payload")
+
+    session = FakeSession()
+    transport = Transport(session=session)
+
+    with open(blob, "rb") as handle:
+        transport.request("https://registry.example/upload", "PUT", data=handle)
+        sent = session.calls[0]["data"]
+
+        # The very same handle is handed over, still unread
+        assert sent is handle
+        assert sent.tell() == 0
+
+
+def test_transport_close_closes_the_session():
+    closed = []
+
+    class ClosableSession(FakeSession):
+        def close(self):
+            closed.append(True)
+
+    transport = Transport(session=ClosableSession())
+    transport.close()
+
+    assert closed == [True]
+
+
+def test_registry_accepts_an_injected_transport():
+    transport = FakeTransport()
+    registry = oras.provider.Registry(
+        hostname="registry.example", insecure=True, transport=transport
+    )
+
+    assert registry.transport is transport
+    # The auth backend is given the same one, so connections are shared
+    assert registry.auth.transport is transport
+
+
+def test_registry_builds_a_transport_when_none_is_given():
+    registry = oras.provider.Registry(hostname="registry.example", tls_verify=False)
+
+    assert isinstance(registry.transport, Transport)
+    assert registry.transport.tls_verify is False
+    assert registry.auth.transport is registry.transport
+
+
+def test_registry_close_closes_the_transport():
+    closed = []
+
+    class ClosableTransport(FakeTransport):
+        def close(self):
+            closed.append(True)
+
+    registry = get_registry(ClosableTransport())
+    registry.close()
+
+    assert closed == [True]
+
+
+def test_get_auth_backend_still_accepts_a_session():
+    """
+    The older way of wiring a backend keeps working.
+    """
+    session = requests.Session()
+    backend = oras.auth.get_auth_backend("token", session, insecure=True)
+
+    assert backend.session is session
+    assert backend.prefix == "http"
+
+
+def test_auth_backend_tls_verify_reads_the_transport():
+    backend = oras.auth.get_auth_backend("token", tls_verify=False)
+
+    assert backend._tls_verify is False
+    assert backend.transport.tls_verify is False
+
+
+def token_response(payload: bytes = b'{"token": "a-token"}'):
+    return make_response(content=payload)
+
+
+def test_token_request_goes_through_the_transport():
+    """
+    Requesting a bearer token is an HTTP call like any other, so it uses the
+    transport rather than reaching for a session of its own.
+    """
+    transport = FakeTransport([token_response()])
+    backend = oras.auth.get_auth_backend("token", transport=transport)
+    backend.set_basic_auth("myuser", "mypass")
+
+    header = auth_utils.parse_auth_header(
+        'Bearer realm="https://auth.example/token",'
+        'service="registry.example",scope="repository:demo:pull"'
+    )
+    token = backend.request_token(header)
+
+    assert token == "a-token"
+    (call,) = transport.calls
+    assert call["method"] == "GET"
+    assert call["url"] == "https://auth.example/token"
+    assert call["params"] == {
+        "service": "registry.example",
+        "scope": "repository:demo:pull",
+    }
+    assert call["headers"]["Authorization"].startswith("Basic ")
+    assert call["headers"]["Service"] == "registry.example"
+
+
+def test_anonymous_token_request_goes_through_the_transport():
+    transport = FakeTransport([token_response(b'{"access_token": "anon"}')])
+    backend = oras.auth.get_auth_backend("token", transport=transport)
+
+    header = auth_utils.parse_auth_header(
+        'Bearer realm="https://auth.example/token",service="registry.example"'
+    )
+    token = backend.request_anonymous_token(header)
+
+    assert token == "anon"
+    (call,) = transport.calls
+    assert call["url"] == "https://auth.example/token"
+    assert call["params"] == {"service": "registry.example"}
+
+
+def test_token_request_returns_nothing_when_refused():
+    transport = FakeTransport([make_response(401, content=b"{}")])
+    backend = oras.auth.get_auth_backend("token", transport=transport)
+
+    header = auth_utils.parse_auth_header('Bearer realm="https://auth.example/token"')
+
+    assert backend.request_token(header) is None

--- a/oras/tests/test_transport.py
+++ b/oras/tests/test_transport.py
@@ -430,3 +430,31 @@ def test_token_request_returns_nothing_when_refused():
     header = auth_utils.parse_auth_header('Bearer realm="https://auth.example/token"')
 
     assert backend.request_token(header) is None
+
+
+def test_do_request_resolves_a_callable_body_for_each_attempt():
+    """
+    A body that can only be read once is produced again when the request is
+    re-sent to answer an authentication challenge.
+    """
+    challenge = make_response(401, headers={"Www-Authenticate": 'Basic realm="r"'})
+    transport = FakeTransport([challenge, make_response(200)])
+    registry = oras.provider.Registry(
+        hostname="registry.example",
+        insecure=True,
+        auth_backend="basic",
+        transport=transport,
+    )
+    registry.auth.set_basic_auth("myuser", "mypass")
+
+    produced = []
+
+    def body():
+        produced.append(b"payload")
+        return b"payload"
+
+    registry.do_request("http://registry.example/v2/", "PUT", data=body)
+
+    assert len(transport.calls) == 2
+    assert [call["data"] for call in transport.calls] == [b"payload", b"payload"]
+    assert produced == [b"payload", b"payload"], "body produced once per attempt"

--- a/oras/transport.py
+++ b/oras/transport.py
@@ -1,0 +1,95 @@
+"""
+HTTP transport for registry interactions.
+
+This module is the only place where requests are actually sent to a registry.
+Keeping execution behind a small boundary means that the rest of the SDK deals
+with urls, headers and responses, and never with session or TLS handling.
+"""
+
+__copyright__ = "Copyright The ORAS Authors."
+__license__ = "Apache-2.0"
+
+from http.cookiejar import DefaultCookiePolicy
+from typing import Optional, Union
+
+import requests
+
+
+class Transport:
+    """
+    Send HTTP requests to a registry with a requests session.
+    """
+
+    def __init__(
+        self,
+        session: Optional[requests.Session] = None,
+        tls_verify: Union[bool, str] = True,
+    ):
+        """
+        Create a new transport.
+
+        :param session: an existing session to use, one is created if not provided
+        :type session: requests.Session
+        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+        :type tls_verify: bool or str
+        """
+        self.session: requests.Session = session or requests.Session()
+        self.tls_verify = tls_verify
+
+        if not tls_verify:
+            requests.packages.urllib3.disable_warnings()  # type: ignore
+
+        # Ignore all cookies: some registries try to set one
+        # and take it as a sign they are talking to a browser,
+        # trying to set further CSRF cookies (Harbor is such a case)
+        self.session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
+
+    def request(
+        self,
+        url: str,
+        method: str = "GET",
+        data: Optional[Union[dict, bytes]] = None,
+        headers: Optional[dict] = None,
+        json: Optional[dict] = None,
+        stream: bool = False,
+    ) -> requests.Response:
+        """
+        Send a single request, without any authentication or retry handling.
+
+        :param url: the URL to issue the request to
+        :type url: str
+        :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
+        :type method: str
+        :param data: data for requests
+        :type data: dict or bytes
+        :param headers: headers for the request
+        :type headers: dict
+        :param json: json data for requests
+        :type json: dict
+        :param stream: stream the responses
+        :type stream: bool
+        """
+        return self.session.request(
+            method,
+            url,
+            data=data,
+            json=json,
+            headers=headers,
+            stream=stream,
+            verify=self.tls_verify,
+        )
+
+
+def successful_response(status_code: int = 200) -> requests.Response:
+    """
+    Create a response for an interaction that did not need to hit the registry.
+
+    This is used when an upload can be skipped (e.g., the blob is already known
+    to exist) but the caller still expects a response to inspect.
+
+    :param status_code: the status code to report
+    :type status_code: int
+    """
+    response = requests.Response()
+    response.status_code = status_code
+    return response

--- a/oras/transport.py
+++ b/oras/transport.py
@@ -105,6 +105,20 @@ class Transport:
         self.session.close()
 
 
+def response_reason(response) -> str:
+    """
+    Get the status line reason of a response.
+
+    requests calls this `reason` and httpx calls it `reason_phrase`, so this is
+    read defensively. It is the one place shared code has to account for the
+    two HTTP clients differing.
+
+    :param response: a response to read the reason from
+    """
+    reason = getattr(response, "reason", None) or getattr(response, "reason_phrase", "")
+    return str(reason or "")
+
+
 def successful_response(status_code: int = 200) -> requests.Response:
     """
     Create a response for an interaction that did not need to hit the registry.

--- a/oras/transport.py
+++ b/oras/transport.py
@@ -1,16 +1,26 @@
 """
 HTTP transport for registry interactions.
 
-This module is the only place where requests are actually sent to a registry.
-Keeping execution behind a small boundary means that the rest of the SDK deals
-with urls, headers and responses, and never with session or TLS handling.
+This module is the only place where requests are actually sent to a registry,
+whether they come from the provider or from an authentication backend.
+
+The transport owns the connection: the session, TLS verification and cookie
+policy. It deliberately does not own anything above HTTP. It knows nothing
+about manifests, blobs, digests or media types, it does not decide when a
+request should be authenticated, and it does not decide when one should be
+retried. Those are registry concerns, and they stay in
+:class:`oras.provider.Registry`.
+
+Keeping execution in one small place is also what makes a different execution
+model possible later: an alternative transport only has to send a request and
+return a response, without any registry logic being written a second time.
 """
 
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
 from http.cookiejar import DefaultCookiePolicy
-from typing import Optional, Union
+from typing import IO, Optional, Union
 
 import requests
 
@@ -48,10 +58,11 @@ class Transport:
         self,
         url: str,
         method: str = "GET",
-        data: Optional[Union[dict, bytes]] = None,
+        data: Optional[Union[dict, bytes, IO]] = None,
         headers: Optional[dict] = None,
         json: Optional[dict] = None,
         stream: bool = False,
+        params: Optional[dict] = None,
     ) -> requests.Response:
         """
         Send a single request, without any authentication or retry handling.
@@ -60,14 +71,17 @@ class Transport:
         :type url: str
         :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
         :type method: str
-        :param data: data for requests
-        :type data: dict or bytes
+        :param data: body for the request. A file object or iterator is sent
+                     without being read into memory first
+        :type data: dict or bytes or IO
         :param headers: headers for the request
         :type headers: dict
         :param json: json data for requests
         :type json: dict
-        :param stream: stream the responses
+        :param stream: stream the response instead of downloading it at once
         :type stream: bool
+        :param params: query string parameters to add to the url
+        :type params: dict
         """
         return self.session.request(
             method,
@@ -76,8 +90,19 @@ class Transport:
             json=json,
             headers=headers,
             stream=stream,
+            params=params,
             verify=self.tls_verify,
         )
+
+    def close(self):
+        """
+        Release the underlying connections.
+
+        Calling this is optional. It is offered for callers that create many
+        short lived clients and do not want to wait for garbage collection to
+        close the pooled connections.
+        """
+        self.session.close()
 
 
 def successful_response(status_code: int = 200) -> requests.Response:

--- a/oras/transport.py
+++ b/oras/transport.py
@@ -86,7 +86,7 @@ class Transport:
         return self.session.request(
             method,
             url,
-            data=data,
+            data=resolve_body(data),
             json=json,
             headers=headers,
             stream=stream,
@@ -117,6 +117,24 @@ def response_reason(response) -> str:
     """
     reason = getattr(response, "reason", None) or getattr(response, "reason_phrase", "")
     return str(reason or "")
+
+
+def resolve_body(data):
+    """
+    Produce the body to send for one attempt at a request.
+
+    A request is sent more than once more often than it looks: to answer an
+    authentication challenge, to refresh a token after a 403, when the retry
+    decorator tries again, and when the client follows a redirect. A body that
+    can only be read once - an iterator over a file - is empty on every attempt
+    after the first, while Content-Length and the digest still describe the
+    first. Callers with such a body pass a callable producing a fresh one, and
+    it is resolved here, at the moment of sending. Re-readable bodies are
+    passed through untouched.
+
+    :param data: the body, or a callable returning a fresh body
+    """
+    return data() if callable(data) else data
 
 
 def successful_response(status_code: int = 200) -> requests.Response:

--- a/oras/transport_async.py
+++ b/oras/transport_async.py
@@ -1,0 +1,177 @@
+"""
+Asynchronous HTTP transport for registry interactions.
+
+This is the async counterpart to :class:`oras.transport.Transport`. It has the
+same responsibility - own the connection and carry out one request - and the
+same deliberate lack of responsibility: it knows nothing about manifests,
+blobs or media types, and it decides neither when a request is authenticated
+nor when one is retried.
+
+httpx is imported lazily so that the async extra stays optional and importing
+oras keeps working without it.
+"""
+
+__copyright__ = "Copyright The ORAS Authors."
+__license__ = "Apache-2.0"
+
+from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Union
+
+if TYPE_CHECKING:
+    import httpx
+
+ASYNC_EXTRA_MESSAGE = """the `httpx` dependency is required for asynchronous support.
+Make sure to install the required extra "async", e.g.: pip install oras[async].
+"""
+
+
+def get_httpx():
+    """
+    Import httpx, with a message pointing at the extra when it is missing.
+    """
+    try:
+        import httpx
+    except ImportError as e:
+        raise ImportError(ASYNC_EXTRA_MESSAGE) from e
+    return httpx
+
+
+class AsyncTransport:
+    """
+    Send HTTP requests to a registry with an httpx async client.
+    """
+
+    def __init__(
+        self,
+        client: Optional["httpx.AsyncClient"] = None,
+        tls_verify: Union[bool, str] = True,
+    ):
+        """
+        Create a new async transport.
+
+        The client is created once and reused, so connections are pooled for
+        the lifetime of the transport rather than per request.
+
+        :param client: an existing httpx client to use, one is created if not provided
+        :type client: httpx.AsyncClient
+        :param tls_verify: enable/disable tls verification or use a custom CA-Bundle
+        :type tls_verify: bool or str
+        """
+        httpx_module = get_httpx()
+        self.tls_verify = tls_verify
+
+        # requests follows redirects by default and the sync transport relies on
+        # that, notably for registries that redirect blob uploads. httpx does
+        # not, so it is asked to here to keep the two behaving the same way.
+        self.client: "httpx.AsyncClient" = client or httpx_module.AsyncClient(
+            verify=tls_verify, follow_redirects=True
+        )
+
+    def _forget_cookies(self):
+        """
+        Drop any cookies the registry tried to set.
+
+        Some registries take an accepted cookie as a sign they are talking to a
+        browser and start requiring CSRF tokens (Harbor is such a case). The
+        sync transport refuses cookies with a cookie policy; httpx has no
+        equivalent, so the jar is emptied instead.
+        """
+        self.client.cookies.clear()
+
+    def _content_arguments(self, data: Any) -> dict:
+        """
+        Map a body onto the argument httpx expects for it.
+
+        requests takes bytes, iterables and form dicts all through `data`,
+        while httpx separates raw bodies (`content`) from form data (`data`).
+        """
+        if data is None:
+            return {}
+        if isinstance(data, dict):
+            return {"data": data}
+        return {"content": data}
+
+    async def request(
+        self,
+        url: str,
+        method: str = "GET",
+        data: Optional[Any] = None,
+        headers: Optional[dict] = None,
+        json: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ) -> "httpx.Response":
+        """
+        Send a single request, without any authentication or retry handling.
+
+        :param url: the URL to issue the request to
+        :type url: str
+        :param method: the method to use (GET, DELETE, POST, PUT, PATCH)
+        :type method: str
+        :param data: body for the request. Bytes, or an iterator of bytes for a
+                     body that should not be held in memory
+        :type data: bytes or iterator or dict
+        :param headers: headers for the request
+        :type headers: dict
+        :param json: json data for the request
+        :type json: dict
+        :param params: query string parameters to add to the url
+        :type params: dict
+        """
+        response = await self.client.request(
+            method,
+            url,
+            headers=headers,
+            json=json,
+            params=params,
+            **self._content_arguments(data),
+        )
+        self._forget_cookies()
+        return response
+
+    def stream(
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ):
+        """
+        Send a request and keep the body unread, for streaming a response.
+
+        Returns an async context manager yielding the response, so that a
+        caller can consume it in chunks without holding a whole blob in
+        memory. Streaming lives here, and not in the registry layer, so that
+        the registry never depends on the HTTP client being used.
+
+        :param url: the URL to issue the request to
+        :type url: str
+        :param method: the method to use
+        :type method: str
+        :param headers: headers for the request
+        :type headers: dict
+        :param params: query string parameters to add to the url
+        :type params: dict
+        """
+        return self.client.stream(method, url, headers=headers, params=params)
+
+    async def aclose(self):
+        """
+        Close the underlying client and release its connections.
+        """
+        await self.client.aclose()
+
+
+async def iter_file(path: str, chunk_size: int) -> AsyncIterator[bytes]:
+    """
+    Read a file in chunks, for uploading it without reading it all at once.
+
+    :param path: the file to read
+    :type path: str
+    :param chunk_size: how much to read at a time
+    :type chunk_size: int
+    """
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk

--- a/oras/transport_async.py
+++ b/oras/transport_async.py
@@ -16,6 +16,8 @@ __license__ = "Apache-2.0"
 
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Union
 
+from oras.transport import resolve_body
+
 if TYPE_CHECKING:
     import httpx
 
@@ -116,16 +118,62 @@ class AsyncTransport:
         :param params: query string parameters to add to the url
         :type params: dict
         """
-        response = await self.client.request(
-            method,
-            url,
-            headers=headers,
-            json=json,
-            params=params,
-            **self._content_arguments(data),
-        )
+        # httpx cannot replay a body it has already streamed, so when the body
+        # can be produced again this follows the redirect itself, with a fresh
+        # body each hop. Anything re-readable is left to httpx as usual.
+        if callable(data):
+            response = await self._request_following_redirects(
+                url, method, data, headers, json, params
+            )
+        else:
+            response = await self.client.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                params=params,
+                **self._content_arguments(data),
+            )
         self._forget_cookies()
         return response
+
+    async def _request_following_redirects(
+        self, url, method, data, headers, json, params, max_redirects: int = 5
+    ):
+        """
+        Send a request whose body can be produced again, following redirects.
+
+        Registries backed by object storage redirect blob uploads, and httpx
+        raises StreamConsumed if it has to replay a streamed body. Each hop
+        therefore asks for the body again rather than reusing a spent one.
+
+        Only 307 and 308 are followed, because they are the redirects that keep
+        the method and the body; anything else is returned for the caller to
+        interpret, as httpx would when a redirect changes the request.
+        """
+        for _ in range(max_redirects):
+            response = await self.client.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                params=params,
+                follow_redirects=False,
+                **self._content_arguments(resolve_body(data)),
+            )
+            if response.status_code not in (307, 308):
+                return response
+
+            location = response.headers.get("location")
+            if not location:
+                return response
+
+            url = str(response.request.url.join(location))
+
+            # the query is carried by the new location from here on
+            params = None
+
+        raise ValueError(f"Too many redirects uploading to {url}")
 
     def stream(
         self,

--- a/oras/transport_async.py
+++ b/oras/transport_async.py
@@ -14,6 +14,7 @@ oras keeps working without it.
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
+from http.cookiejar import DefaultCookiePolicy
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Union
 
 from oras.transport import resolve_body
@@ -68,16 +69,14 @@ class AsyncTransport:
             verify=tls_verify, follow_redirects=True
         )
 
-    def _forget_cookies(self):
-        """
-        Drop any cookies the registry tried to set.
-
-        Some registries take an accepted cookie as a sign they are talking to a
-        browser and start requiring CSRF tokens (Harbor is such a case). The
-        sync transport refuses cookies with a cookie policy; httpx has no
-        equivalent, so the jar is emptied instead.
-        """
-        self.client.cookies.clear()
+        # Ignore all cookies: some registries try to set one and take it as a
+        # sign they are talking to a browser, trying to set further CSRF
+        # cookies (Harbor is such a case). httpx keeps its cookies in a
+        # standard library jar, so it can refuse them with the same policy the
+        # sync transport uses. Refusing is what matters rather than clearing
+        # afterwards, which would leave a cookie in play for the rest of the
+        # request, redirects included, and would miss streamed responses.
+        self.client.cookies.jar.set_policy(DefaultCookiePolicy(allowed_domains=[]))
 
     def _content_arguments(self, data: Any) -> dict:
         """
@@ -134,7 +133,6 @@ class AsyncTransport:
                 params=params,
                 **self._content_arguments(data),
             )
-        self._forget_cookies()
         return response
 
     async def _request_following_redirects(

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.45"
+__version__ = "0.2.46"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"
@@ -19,12 +19,19 @@ INSTALL_REQUIRES = (
     ("requests", {"min_version": None}),
 )
 
-TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
+TESTS_REQUIRES = (
+    ("pytest", {"min_version": "4.6.2"}),
+    ("pytest-asyncio", {"min_version": "0.21.0"}),
+)
 
 DOCKER_REQUIRES = (("docker", {"exact_version": "5.0.1"}),)
 
 ECR_REQUIRES = (("boto3", {"min_version": "1.33.0"}),)
 
+# Asynchronous support is optional: the synchronous client keeps working on
+# requests alone, and only oras[async] pulls in httpx.
+ASYNC_REQUIRES = (("httpx", {"min_version": "0.23.0"}),)
+
 INSTALL_REQUIRES_ALL = (
-    INSTALL_REQUIRES + TESTS_REQUIRES + DOCKER_REQUIRES + ECR_REQUIRES
+    INSTALL_REQUIRES + TESTS_REQUIRES + DOCKER_REQUIRES + ECR_REQUIRES + ASYNC_REQUIRES
 )

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.48"
+__version__ = "0.2.49"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.46"
+__version__ = "0.2.47"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.47"
+__version__ = "0.2.48"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.44"
+__version__ = "0.2.45"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.43"
+__version__ = "0.2.44"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.50"
+__version__ = "0.2.51"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.2.49"
+__version__ = "0.2.50"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ mypy_path = ["oras", "examples"]
 
 [tool.pytest.ini_options]
 markers = ["with_auth: mark for tests requiring authenticated registry access (or not)"]
+asyncio_mode = "strict"

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ if __name__ == "__main__":
     INSTALL_REQUIRES_ALL = get_reqs(lookup, "INSTALL_REQUIRES_ALL")
     DOCKER_REQUIRES = get_reqs(lookup, "DOCKER_REQUIRES")
     ECR_REQUIRES = get_reqs(lookup, "ECR_REQUIRES")
+    ASYNC_REQUIRES = get_reqs(lookup, "ASYNC_REQUIRES")
 
     setup(
         name=NAME,
@@ -92,6 +93,7 @@ if __name__ == "__main__":
             "tests": [TESTS_REQUIRES],
             "docker": [DOCKER_REQUIRES],
             "ecr": [ECR_REQUIRES],
+            "async": [ASYNC_REQUIRES],
         },
         classifiers=[
             "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Summary

This PR addresses [#242](https://github.com/oras-project/oras-py/issues/242) by introducing the architectural foundation required for native asynchronous support in ORAS-py.

The implementation separates Registry/OCI behavior from HTTP transport concerns, allowing synchronous and asynchronous execution paths to share the same high-level logic while using transport implementations appropriate to each execution model.

The async API is designed as an explicit API rather than making existing synchronous methods dynamically behave as either synchronous or asynchronous.

## Issue

Closes #242

## Reviewer

@vsoch — Vanessa Sochat, please review the architectural direction and implementation.

## Architectural Strategy

The main design goal is to avoid maintaining two independent implementations of the Registry logic.

Instead of duplicating the existing `Registry` implementation into an `AsyncRegistry`, the architecture separates:

1. Registry / OCI semantics
2. HTTP transport
3. Sync execution
4. Async execution

The intended architecture is:

```text
                         Public API
                            │
                 ┌──────────┴──────────┐
                 │                     │
             Sync API              Async API
                 │                     │
                 └──────────┬──────────┘
                            │
                   Shared Registry /
                     OCI semantics
                            │
                  ┌─────────┴─────────┐
                  │                   │
           Sync Transport       Async Transport
                  │                   │
               requests              httpx